### PR TITLE
Fix toBytes regression

### DIFF
--- a/smartcard/util/__init__.py
+++ b/smartcard/util/__init__.py
@@ -97,7 +97,7 @@ def toBytes(bytestring):
     >>> toBytes("3B6500   009C1101  0103")
     [59, 101, 0, 0, 156, 17, 1, 1, 3]
     """
-    packedstring = bytestring.replace(' ', '').replace('	','')
+    packedstring = bytestring.replace(' ', '').replace('	','').replace('\n', '')
     try:
         return list(map(lambda x: int(''.join(x), 16), zip(*[iter(packedstring)] * 2)))
     except KeyError:

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -21,6 +21,12 @@ class TestUtil(unittest.TestCase):
         data_in = "3B6500   009C1101  0103"
         self.assertEqual(toBytes(data_in), data_out)
 
+        data_in = '''
+                    3B 65 00
+                    00 9C 11 01
+                    01 03
+                  '''
+        self.assertEqual(toBytes(data_in), data_out)
 
     def test_padd(self):
         data_in = toBytes("3B 65 00 00 9C 11 01 01 03")


### PR DESCRIPTION
When using toBytes on strings containing multiple lines, the results
are wrong. It used to work in pyscard 1.7.0 and before commit
1fd9457a79595061523dfa989f4c38e58b0bb801