### PR TITLE
Fix #15 - installing from `pip` and `easy_install` (Take 2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,24 +18,4 @@ pypi: clean
 test: build
 	$(PYTHON) setup.py test
 
-test_install:
-	# Test installing directly from the local checkout
-	for cmd in "python setup.py install" "pip install ." "easy_install ."; do \
-		pip uninstall -y pyscard &> /dev/null; \
-		git clean -dxf &> /dev/null; \
-		$$cmd &> /dev/null; \
-		python -c "import sys; sys.path.remove(''); import smartcard"; \
-		echo "Installed using '$$cmd' - test exit code: $$?"; \
-	done
-
-	# Test installing using the sdist
-	git clean -dxf &> /dev/null
-	python setup.py sdist &>/dev/null
-	for cmd in "pip install dist/*" "easy_install dist/*"; do \
-		pip uninstall -y pyscard &> /dev/null; \
-		$$cmd &> /dev/null; \
-		python -c "import sys; sys.path.remove(''); import smartcard"; \
-		echo "Installed using '$$cmd' - test exit code: $$?"; \
-	done
-
-.PHONY: clean build pypi test test_install
+.PHONY: clean build pypi test

--- a/Makefile
+++ b/Makefile
@@ -18,4 +18,24 @@ pypi: clean
 test: build
 	$(PYTHON) setup.py test
 
+test_install:
+	# Test installing directly from the local checkout
+	for cmd in "python setup.py install" "pip install ." "easy_install ."; do \
+		pip uninstall -y pyscard &> /dev/null; \
+		git clean -dxf &> /dev/null; \
+		$$cmd &> /dev/null; \
+		python -c "import sys; sys.path.remove(''); import smartcard"; \
+		echo "Installed using '$$cmd' - test exit code: $$?"; \
+	done
+
+	# Test installing using the sdist
+	git clean -dxf &> /dev/null
+	python setup.py sdist &>/dev/null
+	for cmd in "pip install dist/*" "easy_install dist/*"; do \
+		pip uninstall -y pyscard &> /dev/null; \
+		$$cmd &> /dev/null; \
+		python -c "import sys; sys.path.remove(''); import smartcard"; \
+		echo "Installed using '$$cmd' - test exit code: $$?"; \
+	done
+
 .PHONY: clean build pypi test

--- a/Makefile
+++ b/Makefile
@@ -38,4 +38,4 @@ test_install:
 		echo "Installed using '$$cmd' - test exit code: $$?"; \
 	done
 
-.PHONY: clean build pypi test
+.PHONY: clean build pypi test test_install

--- a/setup.py
+++ b/setup.py
@@ -100,12 +100,7 @@ class InstallBuildExtFirst(install):
         if self.old_and_unmanageable or self.single_version_externally_managed:
             return install_orig.install.run(self)
 
-        try:
-            have_called_from_setup = self._called_from_setup is not None
-        except AttributeError:
-            have_called_from_setup = False
-
-        if not have_called_from_setup or not self._called_from_setup(inspect.currentframe()):
+        if not self._called_from_setup(inspect.currentframe()):
             # Run in backward-compatibility mode to support bdist_* commands.
             install_orig.install.run(self)
         else:

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ from distutils.util import get_platform
 import sys
 
 from setuptools import setup, Extension
+from setuptools.command.build_py import build_py
 
 
 if sys.version_info[0:2] < (2, 6):
@@ -83,6 +84,14 @@ VERSION_STR = '%i.%i.%i' % VERSION_INFO[:3]
 VERSION_ALT = '%i,%01i,%01i,%04i' % VERSION_INFO
 
 
+class BuildPyBuildExtFirst(build_py):
+    """Workaround substitude `build_py` command for SWIG"""
+    def run(self):
+        # Run build_ext first so that SWIG generated files are included
+        self.run_command('build_ext')
+        return build_py.run(self)
+
+
 kw = {'name': "pyscard",
       'version': VERSION_STR,
       'description': "Smartcard module for Python.",
@@ -106,6 +115,7 @@ kw = {'name': "pyscard",
                          "smartcard/wx": ["resources/*.ico"],
                        },
 
+      'cmdclass': {'build_py': BuildPyBuildExtFirst},
       # the _scard.pyd extension to build
       'ext_modules': [Extension("smartcard.scard._scard",
                              define_macros=[


### PR DESCRIPTION
- Ensure that the `build_ext` task is called before `build_py` to
  generate SWIG .py files before the Python copy step happens and we
  miss packaging and installing the generated files.
- Add Makefile target `test_install` for testing multiple build and
  install methods on the active Python installation.

This is much cleaner; not sure why it didn't occur to me last night.  I think this should work with any install method entry point into setuptools because it's explicitly hooking into `build_py`, which should always be called.

The new Makefile target isn't the cleanest thing ever.  I just wanted an automated way to test the whole clean installation loop into my local Python install.