### PR TITLE
CardMonitoring: cards can be seen multiple times

### DIFF
--- a/smartcard/CardMonitoring.py
+++ b/smartcard/CardMonitoring.py
@@ -163,7 +163,8 @@ class CardMonitoringThread(object):
 
                     addedcards = []
                     for card in currentcards:
-                        if not self.cards.__contains__(card):
+                        # Always add cards as new if newcardonly is False
+                        if not self.cards.__contains__(card) or not self.newcardonly:
                             addedcards.append(card)
 
                     removedcards = []
@@ -172,9 +173,7 @@ class CardMonitoringThread(object):
                             removedcards.append(card)
 
                     if addedcards != [] or removedcards != []:
-                        if self.newcardonly:
-                            # Record seen cards to skip them
-                            self.cards = currentcards
+                        self.cards = currentcards
                         self.observable.setChanged()
                         self.observable.notifyObservers(
                             (addedcards, removedcards))


### PR DESCRIPTION
Add a newcardonly argument to CardMonitor and CardMonitoringThread so that observers can get notified several times about the same card. Defaults to the current implementation of *not* notifying several times.

I need to check that a RFID reader keeps working under certain conditions (temperature, magnetic field, etc.), and it's not convenient (if not dangerous) to have a human perform these tasks. Thus the need for continuous notifications to detect if the reader stops working.

Is it something you can see go in the core of pyscard?

Also, I modified some tests but couldn't get them to run. How can I get them to run? I tried simply calling `python path/to/testcase_CardMonitor.py` but had errors when importing `local_config`, then I had error importing `configcheck` when trying to run the test suite. I also tried with the `python -m smartcard.test.testcase_CardMonitor` syntax but to no avail. I didn't find any doc around running tests either.

Thanks!