### PR TITLE
Fix SCARD_E_SERVICE_STOPPED from SCardListReaders

### DIFF
--- a/smartcard/Exceptions.py
+++ b/smartcard/Exceptions.py
@@ -70,6 +70,11 @@ class CardServiceException(SmartcardException):
     pass
 
 
+class CardServiceStoppedException(SmartcardException):
+    """Raised when a CardService was stopped"""
+    pass
+
+
 class InvalidATRMaskLengthException(SmartcardException):
     """Raised when an ATR mask does not match an ATR length."""
 

--- a/smartcard/pcsc/PCSCContext.py
+++ b/smartcard/pcsc/PCSCContext.py
@@ -71,5 +71,5 @@ class PCSCContext(object):
         finally:
             PCSCContext.mutex.release()
 
-        return PCSCContext.instance
+        return PCSCContext.instance.getContext()
     establish_new_context = staticmethod(establish_new_context)

--- a/smartcard/pcsc/PCSCContext.py
+++ b/smartcard/pcsc/PCSCContext.py
@@ -53,7 +53,7 @@ class PCSCContext(object):
         PCSCContext.mutex.acquire()
         try:
             if not PCSCContext.instance:
-                self.establish_new_context()
+                self.renewContext()
         finally:
             PCSCContext.mutex.release()
 
@@ -61,7 +61,7 @@ class PCSCContext(object):
         if self.instance:
             return getattr(self.instance, name)
 
-    def establish_new_context():
+    def renewContext():
         PCSCContext.mutex.acquire()
         try:
             if PCSCContext.instance is not None:
@@ -72,4 +72,4 @@ class PCSCContext(object):
             PCSCContext.mutex.release()
 
         return PCSCContext.instance.getContext()
-    establish_new_context = staticmethod(establish_new_context)
+    renewContext = staticmethod(renewContext)

--- a/smartcard/pcsc/PCSCContext.py
+++ b/smartcard/pcsc/PCSCContext.py
@@ -42,6 +42,9 @@ class PCSCContext(object):
         def getContext(self):
             return self.hcontext
 
+        def releaseContext(self):
+            return SCardReleaseContext(self.hcontext)
+
     # the singleton
     mutex = RLock()
     instance = None
@@ -50,10 +53,23 @@ class PCSCContext(object):
         PCSCContext.mutex.acquire()
         try:
             if not PCSCContext.instance:
-                PCSCContext.instance = PCSCContext.__PCSCContextSingleton()
+                self.establish_new_context()
         finally:
             PCSCContext.mutex.release()
 
     def __getattr__(self, name):
         if self.instance:
             return getattr(self.instance, name)
+
+    def establish_new_context():
+        PCSCContext.mutex.acquire()
+        try:
+            if PCSCContext.instance is not None:
+                PCSCContext.instance.releaseContext()
+
+            PCSCContext.instance = PCSCContext.__PCSCContextSingleton()
+        finally:
+            PCSCContext.mutex.release()
+
+        return PCSCContext.instance
+    establish_new_context = staticmethod(establish_new_context)

--- a/smartcard/pcsc/PCSCReader.py
+++ b/smartcard/pcsc/PCSCReader.py
@@ -112,7 +112,7 @@ class PCSCReader(Reader):
         try:
             pcsc_readers = __PCSCreaders__(hcontext, groups)
         except CardServiceStoppedException:
-            hcontext = PCSCContext.establish_new_context()
+            hcontext = PCSCContext.renewContext()
             pcsc_readers = __PCSCreaders__(hcontext, groups)
 
         for reader in pcsc_readers:


### PR DESCRIPTION
OS: Windows 10 Pro (10.0.17134)
Reader (tested on):  Athena ASEDrive V3CR, ARDS JaCarta, Aladdin R.D. JaCarta3
Python version: 3.7
pyscard version: 1.9.7

Behavior:
1. Plug reader to PC (only one!)
2. Start python interpreter
3. Execute
     ``` bash
    >>> from smartcard.System import readers
    ```
4. Unplug reader
5. Plug reader
6. Execute
    ``` bash
    >>> readers()
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "C:\Program Files\Python37\lib\site-packages\smartcard\System.py", line 42, in readers
        return smartcard.reader.ReaderFactory.ReaderFactory.readers(groups)
      File "C:\Program Files\Python37\lib\site-packages\smartcard\reader\ReaderFactory.py", line 58, in readers
        zreaders += fm(groups)
      File "C:\Program Files\Python37\lib\site-packages\smartcard\pcsc\PCSCReader.py", line 110, in readers
        for reader in __PCSCreaders__(hcontext, groups):
      File "C:\Program Files\Python37\lib\site-packages\smartcard\pcsc\PCSCReader.py", line 49, in __PCSCreaders__
        raise ListReadersException(hresult)
    smartcard.pcsc.PCSCExceptions.ListReadersException: 'Failure to list readers: Диспетчер ресурсов смарт-карт завершил работу. '
    ```

How it was fixed:
1. Check for SCARD_E_SERVICE_STOPPED from SCardListReaders
2. Raise CardServiceStoppedException
3. Establish new context for PCSCContext