### PR TITLE
Fix exception for mifare classic cards

### DIFF
--- a/smartcard/pcsc/PCSCCardConnection.py
+++ b/smartcard/pcsc/PCSCCardConnection.py
@@ -202,6 +202,10 @@ class PCSCCardConnection(CardConnection):
                 dictProtocolHeader[pcscprotocolheader] + '. ' + \
                 SCardGetErrorMessage(hresult))
 
+        if len(response) < 2:
+            raise CardConnectionException(
+                'Card returned no valid response')
+            
         sw1 = (response[-2] + 256) % 256
         sw2 = (response[-1] + 256) % 256
 


### PR DESCRIPTION
Fix `list index out of range` for mifare classic cards