### PR TITLE
add reconnect to high-level API

### DIFF
--- a/smartcard/CardConnection.py
+++ b/smartcard/CardConnection.py
@@ -87,6 +87,21 @@ class CardConnection(Observable):
         Observable.setChanged(self)
         Observable.notifyObservers(self, CardConnectionEvent('connect'))
 
+    def reconnect(self, protocol=None, mode=None, disposition=None):
+        """Reconnect to card.
+        @param protocol: a bit mask of the protocols to use, from
+        L{CardConnection.T0_protocol}, L{CardConnection.T1_protocol},
+        L{CardConnection.RAW_protocol}, L{CardConnection.T15_protocol}
+
+        @param mode: SCARD_SHARE_SHARED (default), SCARD_SHARE_EXCLUSIVE or
+        SCARD_SHARE_DIRECT
+
+        @param disposition: SCARD_LEAVE_CARD, SCARD_RESET_CARD (default),
+        SCARD_UNPOWER_CARD or SCARD_EJECT_CARD
+        """
+        Observable.setChanged(self)
+        Observable.notifyObservers(self, CardConnectionEvent('reconnect'))
+
     def disconnect(self):
         """Disconnect from card."""
         Observable.setChanged(self)

--- a/smartcard/CardConnectionDecorator.py
+++ b/smartcard/CardConnectionDecorator.py
@@ -53,6 +53,10 @@ class CardConnectionDecorator(CardConnection):
         """call inner component connect"""
         self.component.connect(protocol, mode, disposition)
 
+    def reconnect(self, protocol=None, mode=None, disposition=None):
+        """call inner component connect"""
+        self.component.reconnect(protocol, mode, disposition)
+
     def disconnect(self):
         """call inner component disconnect"""
         self.component.disconnect()

--- a/smartcard/CardConnectionEvent.py
+++ b/smartcard/CardConnectionEvent.py
@@ -31,8 +31,8 @@ class CardConnectionEvent(object):
 
     def __init__(self, type, args=None):
         """
-        @param type:   'connect', 'disconnect', 'command', 'response'
-        @param args:   None for 'connect' or 'disconnect'
+        @param type:   'connect', 'reconnect', 'disconnect', 'command', 'response'
+        @param args:   None for 'connect', 'reconnect' or 'disconnect'
                 command APDU byte list for 'command'
                 [response data, sw1, sw2] for 'response'
         """

--- a/smartcard/CardConnectionObserver.py
+++ b/smartcard/CardConnectionObserver.py
@@ -53,6 +53,9 @@ class ConsoleCardConnectionObserver(CardConnectionObserver):
         if 'connect' == ccevent.type:
             print('connecting to ' + cardconnection.getReader())
 
+        elif 'reconnect' == ccevent.type:
+            print('reconnecting to ' + cardconnection.getReader())
+
         elif 'disconnect' == ccevent.type:
             print('disconnecting from ' + cardconnection.getReader())
 

--- a/smartcard/pcsc/PCSCCardConnection.py
+++ b/smartcard/pcsc/PCSCCardConnection.py
@@ -147,6 +147,9 @@ class PCSCCardConnection(CardConnection):
 
         If disposition is not specified, do a warm reset (SCARD_RESET_CARD)"""
         CardConnection.reconnect(self, protocol)
+        if self.hcard == None:
+            raise CardConnectionException('Card not connected')
+
         pcscprotocol = translateprotocolmask(protocol)
         if 0 == pcscprotocol:
             pcscprotocol = self.getProtocol()
@@ -156,10 +159,8 @@ class PCSCCardConnection(CardConnection):
 
         # store the way to dispose the card
         if disposition == None:
-            if self.disposition == None:
-                self.disposition = SCARD_RESET_CARD
-        else:
-            self.disposition = disposition
+            disposition = SCARD_RESET_CARD
+        self.disposition = disposition
 
         hresult, dwActiveProtocol = SCardReconnect(self.hcard, mode, pcscprotocol, self.disposition)
         if hresult != 0:
@@ -303,4 +304,3 @@ if __name__ == '__main__':
     print("%r %x %x" % cc.transmit(SELECT + DF_TELECOM))
 
     print(cc.control(CM_IOCTL_GET_FEATURE_REQUEST, []))
-

--- a/smartcard/pcsc/PCSCCardConnection.py
+++ b/smartcard/pcsc/PCSCCardConnection.py
@@ -137,6 +137,53 @@ class PCSCCardConnection(CardConnection):
                     protocol = eval("CardConnection.%s_protocol" % dictProtocol[p])
         PCSCCardConnection.setProtocol(self, protocol)
 
+    def reconnect(self, protocol=None, mode=None, disposition=None):
+        """Reconnect to the card.
+
+        If protocol is not specified, connect with the default
+        connection protocol.
+
+        If mode is not specified, connect with SCARD_SHARE_SHARED.
+
+        If disposition is not specified, do a warm reset (SCARD_RESET_CARD)"""
+        CardConnection.reconnect(self, protocol)
+        pcscprotocol = translateprotocolmask(protocol)
+        if 0 == pcscprotocol:
+            pcscprotocol = self.getProtocol()
+
+        if mode == None:
+            mode = SCARD_SHARE_SHARED
+
+        # store the way to dispose the card
+        if disposition == None:
+            if self.disposition == None:
+                self.disposition = SCARD_RESET_CARD
+        else:
+            self.disposition = disposition
+
+        hresult, dwActiveProtocol = SCardReconnect(self.hcard, mode, pcscprotocol, self.disposition)
+        if hresult != 0:
+            self.hcard = None
+            if hresult in (SCARD_W_REMOVED_CARD, SCARD_E_NO_SMARTCARD):
+                raise NoCardException('Unable to reconnect', hresult=hresult)
+            else:
+                raise CardConnectionException(
+                    'Unable to reconnect with protocol: ' + \
+                    dictProtocol[pcscprotocol] + '. ' + \
+                    SCardGetErrorMessage(hresult))
+
+        protocol = 0
+        if dwActiveProtocol == SCARD_PROTOCOL_T0 | SCARD_PROTOCOL_T1:
+            # special case for T0 | T1
+            # this happen when mode=SCARD_SHARE_DIRECT and no protocol is
+            # then negociated with the card
+            protocol = CardConnection.T0_protocol | CardConnection.T1_protocol
+        else:
+            for p in dictProtocol:
+                if p == dwActiveProtocol:
+                    protocol = eval("CardConnection.%s_protocol" % dictProtocol[p])
+        PCSCCardConnection.setProtocol(self, protocol)
+
     def disconnect(self):
         """Disconnect from the card."""
 


### PR DESCRIPTION
I added the reconnect method to `CardConnection()` regarding the issue [#107](https://github.com/LudovicRousseau/pyscard/issues/107) that simply make a call to `SCardReconnect()`.

The default mode is `SCARD_SHARE_SHARED` and the default disposition is `SCARD_RESET_CARD` if none as been given and if the connection object doesn't already have one.

I also added a "reconnect" event for the `CardConnectionObserver`.