### PR TITLE
Removing platform sources for mingw under windows (building under msys2)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,8 @@ platform_extra_link_args = []   # ['-ggdb']
 if platform.system() == 'Windows':
     platform__cc_defines = [('WIN32', '100')]
     platform_swig_opts = ['-DWIN32']
-    platform_sources = ['smartcard/scard/scard.rc'] if 'mingw' not in get_platform() else []
+    if 'mingw' not in get_platform():
+        platform_sources = ['smartcard/scard/scard.rc']
     platform_libraries = ['winscard']
 
 elif platform.system() == 'Darwin':

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ import platform
 import shlex
 import subprocess
 import sys
+from sysconfig import get_platform
 
 from setuptools import setup, Extension
 from setuptools.command.build_py import build_py
@@ -43,7 +44,7 @@ platform_extra_link_args = []   # ['-ggdb']
 if platform.system() == 'Windows':
     platform__cc_defines = [('WIN32', '100')]
     platform_swig_opts = ['-DWIN32']
-    platform_sources = ['smartcard/scard/scard.rc']
+    platform_sources = ['smartcard/scard/scard.rc'] if 'mingw' not in get_platform() else []
     platform_libraries = ['winscard']
 
 elif platform.system() == 'Darwin':


### PR DESCRIPTION
This small changes allows to build pyscard under MSYS2/mingw environment on Windows:
```
python setup.py build
python setup.py install
```

The build process has errors, but it does complete. And the installation results in a working solution. 
Note: tested under mingw64 (32-bit not tested, but most likely works in the same way).