### PR TITLE
Build Windows binaries also for Python 3.11

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,7 +24,7 @@ jobs:
         python --version
         python -c "import struct; print(struct.calcsize('P') * 8)"
         python -m pip install --upgrade pip
-        pip install -r dev-requirements.txt
+        python -m pip install -r dev-requirements.txt
 
         choco install swig --version 2.0.12 --allow-empty-checksums --yes --limit-output
         swig -version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,10 @@ environment:
 
   matrix:
 
+    - PYTHON: "C:\\Python311-x64"
+      PYTHON_VERSION: "3.11.x"
+      PYTHON_ARCH: "64"
+
     - PYTHON: "C:\\Python310-x64"
       PYTHON_VERSION: "3.10.x"
       PYTHON_ARCH: "64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,7 +73,8 @@ install:
   # compiled extensions and are not provided as pre-built wheel packages,
   # pip will build them from source using the MSVC compiler matching the
   # target Python version and architecture
-  - "%CMD_IN_ENV% pip install -r dev-requirements.txt"
+  - "%CMD_IN_ENV% python -m pip install --upgrade pip"
+  - "%CMD_IN_ENV% python -m pip install -r dev-requirements.txt"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
 coverage
 coveralls
+setuptools<65.0.0
 wheel

--- a/setup.py
+++ b/setup.py
@@ -140,6 +140,7 @@ kw = {'name': "pyscard",
           'Programming Language :: Python :: 3.8',
           'Programming Language :: Python :: 3.9',
           'Programming Language :: Python :: 3.10',
+          'Programming Language :: Python :: 3.11',
           'Topic :: Security',
           ]
       }


### PR DESCRIPTION
Makes pyscard available for Python 3.11 as a downloadable installation artifact.