### PR TITLE
added SCARD_E_NO_SERVICE to renewContext

### DIFF
--- a/smartcard/Exceptions.py
+++ b/smartcard/Exceptions.py
@@ -78,6 +78,10 @@ class CardServiceStoppedException(SmartcardException):
     """Raised when the CardService was stopped"""
     pass
 
+class CardServiceNotFoundException(SmartcardException):
+    """Raised when the CardService is not found"""
+    pass
+
 
 class InvalidATRMaskLengthException(SmartcardException):
     """Raised when an ATR mask does not match an ATR length."""

--- a/smartcard/pcsc/PCSCCardRequest.py
+++ b/smartcard/pcsc/PCSCCardRequest.py
@@ -89,7 +89,7 @@ class PCSCCardRequest(AbstractCardRequest):
 
         # get inserted readers
         hresult, pcscreaders = SCardListReaders(self.hcontext, [])
-        if SCARD_E_SERVICE_STOPPED == hresult or SCARD_E_NO_SERVICE == hresult:
+        if hresult in (SCARD_E_SERVICE_STOPPED, SCARD_E_NO_SERVICE):
             self.hcontext = PCSCContext().renewContext()
             hresult, pcscreaders = SCardListReaders(self.hcontext, [])
         if SCARD_E_NO_READERS_AVAILABLE == hresult:

--- a/smartcard/pcsc/PCSCCardRequest.py
+++ b/smartcard/pcsc/PCSCCardRequest.py
@@ -89,7 +89,7 @@ class PCSCCardRequest(AbstractCardRequest):
 
         # get inserted readers
         hresult, pcscreaders = SCardListReaders(self.hcontext, [])
-        if SCARD_E_SERVICE_STOPPED == hresult:
+        if SCARD_E_SERVICE_STOPPED == hresult or SCARD_E_NO_SERVICE == hresult:
             self.hcontext = PCSCContext().renewContext()
             hresult, pcscreaders = SCardListReaders(self.hcontext, [])
         if SCARD_E_NO_READERS_AVAILABLE == hresult:

--- a/smartcard/pcsc/PCSCReader.py
+++ b/smartcard/pcsc/PCSCReader.py
@@ -112,11 +112,7 @@ class PCSCReader(Reader):
 
         try:
             pcsc_readers = __PCSCreaders__(hcontext, groups)
-        except CardServiceStoppedException:
-            hcontext = PCSCContext.renewContext()
-            pcsc_readers = __PCSCreaders__(hcontext, groups)
-
-        except CardServiceNotFoundException:
+        except (CardServiceStoppedException, CardServiceNotFoundException):
             hcontext = PCSCContext.renewContext()
             pcsc_readers = __PCSCreaders__(hcontext, groups)
 

--- a/smartcard/pcsc/PCSCReader.py
+++ b/smartcard/pcsc/PCSCReader.py
@@ -46,6 +46,8 @@ def __PCSCreaders__(hcontext, groups=[]):
             readers = []
         elif hresult == SCARD_E_SERVICE_STOPPED:
             raise CardServiceStoppedException()
+        elif hresult == SCARD_E_NO_SERVICE:
+            raise CardServiceNotFoundException()
         else:
             raise ListReadersException(hresult)
 
@@ -111,6 +113,10 @@ class PCSCReader(Reader):
         try:
             pcsc_readers = __PCSCreaders__(hcontext, groups)
         except CardServiceStoppedException:
+            hcontext = PCSCContext.renewContext()
+            pcsc_readers = __PCSCreaders__(hcontext, groups)
+
+        except CardServiceNotFoundException:
             hcontext = PCSCContext.renewContext()
             pcsc_readers = __PCSCreaders__(hcontext, groups)
 


### PR DESCRIPTION
Added SCARD_E_NO_SERVICE to renewContext. Added CardServiceNotFoundException exception. Worked for me on the latest Windows 10 catching both stop and no service to renew the context.