### PR TITLE
Provide binary wheels for Windows x86 architecture 

### DIFF
--- a/.github/workflows/windows_all.yml
+++ b/.github/workflows/windows_all.yml
@@ -1,0 +1,46 @@
+name: Windows Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        windows-arch: ['x86', 'x64']
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }} ${{ matrix.windows-arch }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: ${{ matrix.windows-arch }}
+
+    - name: Install build tools
+      run: |
+        python --version
+        python -c "import struct; print(struct.calcsize('P') * 8)"
+        python -m pip install --upgrade pip
+        pip install -r dev-requirements.txt
+
+        choco install swig --version 2.0.12 --allow-empty-checksums --yes --limit-output
+        swig -version
+
+    - name: Build
+      run: |
+        python setup.py sdist
+        python setup.py bdist
+        python setup.py bdist_wheel
+        python setup.py install
+
+    - name: Tests
+      run: python setup.py test
+
+    - uses: actions/upload-artifact@v3
+      with:
+        path: dist

--- a/.github/workflows/windows_x86.yml
+++ b/.github/workflows/windows_x86.yml
@@ -1,0 +1,45 @@
+name: Windows Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: x86
+
+    - name: Install build tools
+      run: |
+        python --version
+        python -c "import struct; print(struct.calcsize('P') * 8)"
+        python -m pip install --upgrade pip
+        pip install -r dev-requirements.txt
+
+        choco install swig --version 2.0.12 --allow-empty-checksums --yes --limit-output
+        swig -version
+
+    - name: Build
+      run: |
+        python setup.py sdist
+        python setup.py bdist
+        python setup.py bdist_wheel
+        python setup.py install
+
+    - name: Tests
+      run: python setup.py test
+
+    - uses: actions/upload-artifact@v3
+      with:
+        path: dist


### PR DESCRIPTION
Would it be possible to provide binary wheels for Windows x86 architecture in Pypi (such as pyscard-2.0.7-cp310-cp310-win32.whl)?

We use pyscard to integrate Satochip smartcards in [Electrum wallet](https://github.com/Toporin/electrum-satochip).
The Electrum distributables are built using automated scripts running in Docker to ensure reproducibility. 
For Windows, a Ubuntu image is used with wine on x86.

Previously, win32 wheels have been provided for some release (such as v2.0.0), but it's not available for the later releases.

As far as I can tell, it is possible to generate win32 wheel for pyscard using Github Actions using one of these recipe: https://github.com/Toporin/pyscard/blob/master/.github/workflows/windows_all.yml
https://github.com/Toporin/pyscard/blob/master/.github/workflows/windows_x86.yml
