### PR TITLE
Fix `swig` build dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools","swig"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Alternative: include an error note to say to install swig from system package manager