### PR TITLE
Fix use of undefined variable 'hresult' in exceptions

### DIFF
--- a/smartcard/pcsc/PCSCCardConnection.py
+++ b/smartcard/pcsc/PCSCCardConnection.py
@@ -150,8 +150,7 @@ class PCSCCardConnection(CardConnection):
         (C{smartcard.scard.SCARD_RESET_CARD})"""
         CardConnection.reconnect(self, protocol)
         if self.hcard is None:
-            raise CardConnectionException('Card not connected',
-                                          hresult=hresult)
+            raise CardConnectionException('Card not connected')
 
         pcscprotocol = translateprotocolmask(protocol)
         if 0 == pcscprotocol:
@@ -211,8 +210,7 @@ class PCSCCardConnection(CardConnection):
         """Return card ATR"""
         CardConnection.getATR(self)
         if self.hcard is None:
-            raise CardConnectionException('Card not connected',
-                                          hresult=hresult)
+            raise CardConnectionException('Card not connected')
         hresult, reader, state, protocol, atr = SCardStatus(self.hcard)
         if hresult != 0:
             raise CardConnectionException(


### PR DESCRIPTION
The following commit introrudced the inclusion of hresult in exceptions that are raised:

commit 395cdc46a0fda86af79523a2d18bef06b96a234b
Author: Ludovic Rousseau <ludovic.rousseau@free.fr>
Date:   Sun Apr 23 18:27:24 2023 +0200

However, it also introduces hresult into 'raise' statements where no hresult exists [yet].  This in turn causes double exceptions like this:
```
Traceback (most recent call last):
  File "/crypt/space/home/laforge/projects/git/pysim/./contrib/card2server.py", line 106, in <module>
    'atr': tp.get_atr(),
           ^^^^^^^^^^^^
  File "/crypt/space/home/laforge/projects/git/pysim/contrib/pySim/transport/pcsc.py", line 95, in get_atr
    return self._con.getATR()
           ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/smartcard/CardConnectionDecorator.py", line 66, in getATR
    return self.component.getATR()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/smartcard/CardConnectionDecorator.py", line 66, in getATR
    return self.component.getATR()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/smartcard/pcsc/PCSCCardConnection.py", line 215, in getATR
    hresult=hresult)
            ^^^^^^^
UnboundLocalError: cannot access local variable 'hresult' where it is not associated with a value
```