### PR TITLE
Remove deprecated/removed `test_suite` setuptools option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,8 +127,6 @@ kw = {'name': "pyscard",
             'Pyro': ['Pyro'],
             },
 
-      'test_suite': 'test',
-
       'classifiers': [
           'Development Status :: 5 - Production/Stable',
           'License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)',


### PR DESCRIPTION
This PR introduces the following changes:

* Remove the deprecated/removed `test_suite` setuptools option.

The setuptools documentation states that [the `test_suite` option has been deprecated](https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-test-suite) since setuptools 41.5.0, and as of setuptools 75.1.0 I'm seeing this error when I run `make test`:

```
/home/kurt/dev/pr-pyscard/.venv/lib/python3.12/site-packages/setuptools/_distutils/dist.py:261: UserWarning: Unknown distribution option: 'test_suite'
```

This error also [appears in CI runs on Python 3.10](https://github.com/LudovicRousseau/pyscard/actions/runs/10779523749/job/29893235493#step:5:65):

```
/tmp/build-env-pfg_p5ge/lib/python3.10/site-packages/setuptools/_distutils/dist.py:261: UserWarning: Unknown distribution option: 'test_suite'
```