### PR TITLE
Remove Python 2 conditional code

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,9 +1,7 @@
 [MAIN]
 
-# Analyse import fallback blocks. This can be used to support both Python 2 and
-# 3 compatible code, which means that the block might have code that exists
-# only in one or another interpreter, leading to false positives when analysed.
-analyse-fallback-blocks=no
+# Analyse import fallback blocks.
+analyse-fallback-blocks=yes
 
 # Clear in-memory caches upon conclusion of linting. Useful if running pylint
 # in a server-like mode.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+Unreleased changes
+==================
+   * Remove Python 2 conditional code
+
 2.1.1 (September 2024)
 ======================
    * Fix a regression introduced in 2.1.0

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -86,7 +86,7 @@ setup.py build_ext install
 ```
 
 This will build pyscard and install it in the site-packages directory of
-your python distribution, e.g. `c:\python25\Lib\site-packages\smartcard`.
+your python distribution, e.g. `c:\python312\Lib\site-packages\smartcard`.
 
 This install procedure does not install the documentation, examples or test
 files.
@@ -114,7 +114,7 @@ sudo python setup.py install
 
 This will build pyscard and install it in the site-packages directory of
 your python distribution, e.g.
-`/usr/lib/python2.7/site-packages/smartcard`.
+`/usr/lib/python3.12/site-packages/smartcard`.
 
 Developer documentation, unit tests and examples
 ------------------------------------------------

--- a/smartcard/ReaderMonitoring.py
+++ b/smartcard/ReaderMonitoring.py
@@ -106,14 +106,8 @@ class ReaderMonitor(Observable):
                     # avoid a deadlock; addObserver and notifyObservers called
                     # in the ReaderMonitoringThread run() method are
                     # synchronized
-                    try:
-                        # Python 3.x
-                        import _thread
-                        _thread.start_new_thread(self.rmthread.start, ())
-                    except:
-                        # Python 2.x
-                        import thread
-                        thread.start_new_thread(self.rmthread.start, ())
+                    import _thread
+                    _thread.start_new_thread(self.rmthread.start, ())
         else:
             observer.update(self, (self.rmthread.readers, []))
 

--- a/smartcard/guid.py
+++ b/smartcard/guid.py
@@ -35,12 +35,7 @@ def strToGUID(s):
     [103, 22, 79, 173, 117, 234, 36, 65, 132, 212, 100, 27, 59, 25, 124, 101]
     """
     dat = uuid.UUID(hex=s)
-    if isinstance(dat.bytes_le, str):
-        # Python 2
-        dat = [ord(e) for e in dat.bytes_le]
-    else:
-        # Python 3
-        dat = list(dat.bytes_le)
+    dat = list(dat.bytes_le)
     return dat
 
 
@@ -51,10 +46,7 @@ def GUIDToStr(g):
     ...            132, 212, 100, 27, 59, 25, 124, 101])
     '{AD4F1667-EA75-4124-84D4-641B3B197C65}'
     """
-    try:
-        dat = uuid.UUID(bytes_le=bytes(g))
-    except:
-        dat = uuid.UUID(bytes_le=''.join(map(chr, g)))
+    dat = uuid.UUID(bytes_le=bytes(g))
     return '{' + str(dat).upper() + '}'
 
 

--- a/smartcard/pcsc/PCSCCardRequest.py
+++ b/smartcard/pcsc/PCSCCardRequest.py
@@ -106,7 +106,7 @@ class PCSCCardRequest(AbstractCardRequest):
         # otherwise use only the asked readers that are inserted
         else:
             for reader in self.readersAsked:
-                if not isinstance(reader, type("")):
+                if not isinstance(reader, str):
                     reader = str(reader)
                 if reader in pcscreaders:
                     readers = readers + [reader]

--- a/smartcard/pcsc/PCSCReader.py
+++ b/smartcard/pcsc/PCSCReader.py
@@ -38,7 +38,7 @@ def __PCSCreaders__(hcontext, groups=[]):
     """
 
     # in case we have a string instead of a list
-    if isinstance(groups, type("")):
+    if isinstance(groups, str):
         groups = [groups]
     hresult, readers = SCardListReaders(hcontext, groups)
     if hresult != SCARD_S_SUCCESS:

--- a/smartcard/pyro/server/RemoteReaderServer.py
+++ b/smartcard/pyro/server/RemoteReaderServer.py
@@ -23,8 +23,6 @@ along with pyscard; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-from __future__ import print_function
-
 try:
     import Pyro.core
     import Pyro.naming

--- a/smartcard/reader/ReaderGroups.py
+++ b/smartcard/reader/ReaderGroups.py
@@ -77,13 +77,13 @@ class innerreadergroups(ulist):
 
     def addreadergroup(self, newgroup):
         """Add a reader group"""
-        if not isinstance(newgroup, type("")):
+        if not isinstance(newgroup, str):
             raise BadReaderGroupException
         self += newgroup
 
     def removereadergroup(self, group):
         """Remove a reader group"""
-        if not isinstance(group, type("")):
+        if not isinstance(group, str):
             raise BadReaderGroupException
         self.remove(group)
 

--- a/smartcard/scard/makefile
+++ b/smartcard/scard/makefile
@@ -24,7 +24,7 @@
 
 # where python and swig are located usually on my machine
 # adapt to your configuration
-# the pythondev must contain the debug libraries (e.g. python25_d.lib)
+# the pythondev must contain the debug libraries
 pythondir=c:\projects\pyscard\factory\python
 pythondebugdir=c:\projects\pyscard\factory\pythondev
 pythonpackagedir=$(pythondir)\Lib\site-packages\smartcard\scard

--- a/smartcard/test/framework/testcase_readergroups.py
+++ b/smartcard/test/framework/testcase_readergroups.py
@@ -92,7 +92,7 @@ if 'winscard' == resourceManager and \
             zgroups = [self.pinpadgroup] + groups
             self.assertEqual(groups, groupssnapshot)
             self.assertEqual(zgroups, groupssnapshot + [self.pinpadgroup])
-            self.assertTrue(isinstance(zgroups, type([])))
+            self.assertTrue(isinstance(zgroups, list))
             self.assertTrue(isinstance(groups, type(readergroups())))
 
             # add pinpad a tiwce and biometric once
@@ -101,7 +101,7 @@ if 'winscard' == resourceManager and \
             self.assertEqual(groups, groupssnapshot)
             self.assertEqual(
                 zgroups, groupssnapshot + [self.pinpadgroup, self.biogroup])
-            self.assertTrue(isinstance(zgroups, type([])))
+            self.assertTrue(isinstance(zgroups, list))
             self.assertTrue(isinstance(groups, type(readergroups())))
 
         def testcase_readergroup_append(self):

--- a/smartcard/test/scard/testcase_geterrormessage.py
+++ b/smartcard/test/scard/testcase_geterrormessage.py
@@ -47,9 +47,7 @@ class testcase_geterrormessage(unittest.TestCase):
         hresult, readers = SCardListReaders(self.hcontext, [])
         self.assertEqual(hresult, 0)
 
-        # we need a long on Python 2.x like 123L
-        # but Python 3 do not support the 123L notation any more
-        hresult = SCardReleaseContext(pow(2,63) >> 60)
+        hresult = SCardReleaseContext(pow(2, 63) >> 60)
         if 'win32' == sys.platform:
             self.assertEqual((
                 SCARD_E_INVALID_HANDLE == hresult or \

--- a/smartcard/ulist.py
+++ b/smartcard/ulist.py
@@ -84,7 +84,7 @@ class ulist(list):
         """Remove from other items already in list."""
         if not isinstance(_other, type(self)) \
            and not isinstance(_other, type(list)) \
-           and not isinstance(_other, type([])):
+           and not isinstance(_other, list):
             other = [_other]
         else:
             other = list(_other)

--- a/test/test_ATR.py
+++ b/test/test_ATR.py
@@ -1,21 +1,17 @@
 # -*- coding: utf-8 -*-
 
+import io
 import sys
 import unittest
 from smartcard.ATR import ATR
 from smartcard.Exceptions import SmartcardException
 from smartcard.util import toBytes
 
-if sys.version_info >= (3, 0):
-    from io import StringIO
-else:
-    from StringIO import StringIO
-
 
 class TestUtil(unittest.TestCase):
 
     def setUp(self):
-        self.held, sys.stdout = sys.stdout, StringIO()
+        self.held, sys.stdout = sys.stdout, io.StringIO()
 
     def test_ATR1(self):
         atr = [0x3F, 0x65, 0x25, 0x00, 0x2C, 0x09, 0x69, 0x90, 0x00]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist =
+    pylint
     py311
     py312
 
@@ -12,3 +13,10 @@ commands =
     coverage report
     coverage html
 
+[testenv:pylint]
+base_python = py3.12
+skip_install = True
+deps =
+    pylint
+commands =
+    - pylint --errors-only smartcard


### PR DESCRIPTION
This PR introduces the following changes:

* Remove Python 2 conditional code
* Add a tox `pylint` environment that mirrors the CI configuration.

> [!NOTE]
>
> No Python 3 / C compatibility functions were modified yet, but these need to be removed as well.
>
> These can be found later by searching the codebase for `PY_MAJOR_VERSION` and `PY_VERSION_HEX` references.