### PR TITLE
Migrate CI to use the official Coveralls action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,10 +66,10 @@ jobs:
           python3 -m coverage erase
           python3 -m coverage run -m pytest
           python3 -m coverage report
+          python3 -m coverage xml
 
       - name: Coveralls
-        if: matrix.os == 'ubuntu-latest'
-        uses: AndreMiras/coveralls-python-action@develop
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ Unreleased changes
    * Remove Python 2 conditional code
    * Migrate a `src/` layout.
    * Support only Python 3.9 and higher
+   * Migrate CI to use the official Coveralls action
 
 2.1.1 (September 2024)
 ======================


### PR DESCRIPTION
This PR introduces the following changes:

* Migrate CI to use the official Coveralls action

This lifts the restriction that only Linux coverage reports can be submitted, and helps prepare for standardized testing across all platforms.

I'll monitor the test runs to confirm that results are uploaded for both Linux and macOS.