### PR TITLE
Migrate to pytest features

### DIFF
--- a/test/test_ATR.py
+++ b/test/test_ATR.py
@@ -1,101 +1,97 @@
-# -*- coding: utf-8 -*-
+import pytest
 
-import io
-import sys
-import unittest
 from smartcard.ATR import ATR
 from smartcard.Exceptions import SmartcardException
 from smartcard.util import toBytes
 
 
-class TestUtil(unittest.TestCase):
-
-    def setUp(self):
-        self.held, sys.stdout = sys.stdout, io.StringIO()
-
-    def test_ATR1(self):
-        atr = [0x3F, 0x65, 0x25, 0x00, 0x2C, 0x09, 0x69, 0x90, 0x00]
-        data_out = """TB1: 25
+def test_atr1(capsys):
+    atr = [0x3F, 0x65, 0x25, 0x00, 0x2C, 0x09, 0x69, 0x90, 0x00]
+    data_out = """TB1: 25
 TC1: 0
 supported protocols T=0
 T=0 supported: True
 T=1 supported: False
-	clock rate conversion factor: 372
-	bit rate adjustment factor: 1
-	maximum programming current: 50
-	programming voltage: 30
-	guard time: 0
+\tclock rate conversion factor: 372
+\tbit rate adjustment factor: 1
+\tmaximum programming current: 50
+\tprogramming voltage: 30
+\tguard time: 0
 nb of interface bytes: 2
 nb of historical bytes: 5
 """
-        a = ATR(atr)
-        a.dump()
-        output = sys.stdout.getvalue()
-        self.assertEqual(output, data_out)
+    a = ATR(atr)
+    a.dump()
+    stdout, _ = capsys.readouterr()
+    assert stdout == data_out
 
-    def test_ATR2(self):
-        atr = [0x3F, 0x65, 0x25, 0x08, 0x93, 0x04, 0x6C, 0x90, 0x00]
-        data_out = """TB1: 25
+
+def test_atr2(capsys):
+    atr = [0x3F, 0x65, 0x25, 0x08, 0x93, 0x04, 0x6C, 0x90, 0x00]
+    data_out = """TB1: 25
 TC1: 8
 supported protocols T=0
 T=0 supported: True
 T=1 supported: False
-	clock rate conversion factor: 372
-	bit rate adjustment factor: 1
-	maximum programming current: 50
-	programming voltage: 30
-	guard time: 8
+\tclock rate conversion factor: 372
+\tbit rate adjustment factor: 1
+\tmaximum programming current: 50
+\tprogramming voltage: 30
+\tguard time: 8
 nb of interface bytes: 2
 nb of historical bytes: 5
 """
-        a = ATR(atr)
-        a.dump()
-        output = sys.stdout.getvalue()
-        self.assertEqual(output, data_out)
+    a = ATR(atr)
+    a.dump()
 
-    def test_ATR3(self):
-        atr = [0x3B, 0x16, 0x94, 0x7C, 0x03, 0x01, 0x00, 0x00, 0x0D]
-        data_out = """TA1: 94
+    stdout, _ = capsys.readouterr()
+    assert stdout == data_out
+
+
+def test_atr3(capsys):
+    atr = [0x3B, 0x16, 0x94, 0x7C, 0x03, 0x01, 0x00, 0x00, 0x0D]
+    data_out = """TA1: 94
 supported protocols T=0
 T=0 supported: True
 T=1 supported: False
-	clock rate conversion factor: 512
-	bit rate adjustment factor: 8
-	maximum programming current: 50
-	programming voltage: 5
-	guard time: None
+\tclock rate conversion factor: 512
+\tbit rate adjustment factor: 8
+\tmaximum programming current: 50
+\tprogramming voltage: 5
+\tguard time: None
 nb of interface bytes: 1
 nb of historical bytes: 6
 """
-        a = ATR(atr)
-        a.dump()
-        output = sys.stdout.getvalue()
-        self.assertEqual(output, data_out)
+    a = ATR(atr)
+    a.dump()
+    stdout, _ = capsys.readouterr()
+    assert stdout == data_out
 
-    def test_ATR4(self):
-        atr = [0x3B, 0x65, 0x00, 0x00, 0x9C, 0x11, 0x01, 0x01, 0x03]
-        data_out = """TB1: 0
+
+def test_atr4(capsys):
+    atr = [0x3B, 0x65, 0x00, 0x00, 0x9C, 0x11, 0x01, 0x01, 0x03]
+    data_out = """TB1: 0
 TC1: 0
 supported protocols T=0
 T=0 supported: True
 T=1 supported: False
-	clock rate conversion factor: 372
-	bit rate adjustment factor: 1
-	maximum programming current: 25
-	programming voltage: 5
-	guard time: 0
+\tclock rate conversion factor: 372
+\tbit rate adjustment factor: 1
+\tmaximum programming current: 25
+\tprogramming voltage: 5
+\tguard time: 0
 nb of interface bytes: 2
 nb of historical bytes: 5
 """
-        a = ATR(atr)
-        a.dump()
-        output = sys.stdout.getvalue()
-        self.assertEqual(output, data_out)
+    a = ATR(atr)
+    a.dump()
+    stdout, _ = capsys.readouterr()
+    assert stdout == data_out
 
-    def test_ATR5(self):
-        atr = [0x3B, 0xE3, 0x00, 0xFF, 0x81, 0x31, 0x52, 0x45, 0xA1,
-               0xA2, 0xA3, 0x1B]
-        data_out = """TB1: 0
+
+def test_atr5(capsys):
+    atr = [0x3B, 0xE3, 0x00, 0xFF, 0x81, 0x31, 0x52, 0x45, 0xA1, 0xA2, 0xA3, 0x1B]
+    data_out = """TB1: 0
 TC1: ff
 TD1: 81
 TD2: 31
@@ -105,23 +101,23 @@ supported protocols T=1
 T=0 supported: False
 T=1 supported: True
 checksum: 27
-	clock rate conversion factor: 372
-	bit rate adjustment factor: 1
-	maximum programming current: 25
-	programming voltage: 5
-	guard time: 255
+\tclock rate conversion factor: 372
+\tbit rate adjustment factor: 1
+\tmaximum programming current: 25
+\tprogramming voltage: 5
+\tguard time: 255
 nb of interface bytes: 6
 nb of historical bytes: 3
 """
-        a = ATR(atr)
-        a.dump()
-        output = sys.stdout.getvalue()
-        self.assertEqual(output, data_out)
+    a = ATR(atr)
+    a.dump()
+    stdout, _ = capsys.readouterr()
+    assert stdout == data_out
 
-    def test_ATR6(self):
-        atr = [0x3B, 0xE5, 0x00, 0x00, 0x81, 0x21, 0x45, 0x9C, 0x10,
-               0x01, 0x00, 0x80, 0x0D]
-        data_out = """TB1: 0
+
+def test_atr6(capsys):
+    atr = [0x3B, 0xE5, 0x00, 0x00, 0x81, 0x21, 0x45, 0x9C, 0x10, 0x01, 0x00, 0x80, 0x0D]
+    data_out = """TB1: 0
 TC1: 0
 TD1: 81
 TD2: 21
@@ -130,34 +126,33 @@ supported protocols T=1
 T=0 supported: False
 T=1 supported: True
 checksum: 13
-	clock rate conversion factor: 372
-	bit rate adjustment factor: 1
-	maximum programming current: 25
-	programming voltage: 5
-	guard time: 0
+\tclock rate conversion factor: 372
+\tbit rate adjustment factor: 1
+\tmaximum programming current: 25
+\tprogramming voltage: 5
+\tguard time: 0
 nb of interface bytes: 5
 nb of historical bytes: 5
 """
-        a = ATR(atr)
-        a.dump()
-        output = sys.stdout.getvalue()
-        self.assertEqual(output, data_out)
+    a = ATR(atr)
+    a.dump()
+    stdout, _ = capsys.readouterr()
+    assert stdout == data_out
 
-    def test_ATR_TS(self):
-        atr = [0x42]
-        with self.assertRaises(SmartcardException):
-            ATR(atr)
 
-    def test_ATR_get(self):
-        atr = "3B F2 95 12 34 01 36 06"
-        a = ATR(toBytes(atr))
-        self.assertEqual(a.getTA1(), 0x95)
-        self.assertEqual(a.getTB1(), 0x12)
-        self.assertEqual(a.getTC1(), 0x34)
-        self.assertEqual(a.getTD1(), 0x01)
-        self.assertEqual(a.getHistoricalBytes(), [0x36, 0x06])
-        self.assertFalse(a.isT15Supported())
-        self.assertEqual(str(a), atr)
+def test_atr_ts():
+    atr = [0x42]
+    with pytest.raises(SmartcardException):
+        ATR(atr)
 
-if __name__ == '__main__':
-    unittest.main(buffer=True)
+
+def test_atr_get():
+    atr = "3B F2 95 12 34 01 36 06"
+    a = ATR(toBytes(atr))
+    assert a.getTA1() == 0x95
+    assert a.getTB1() == 0x12
+    assert a.getTC1() == 0x34
+    assert a.getTD1() == 0x01
+    assert a.getHistoricalBytes(), [0x36 == 0x06]
+    assert a.isT15Supported() is False
+    assert str(a) == atr

--- a/test/test_PCSC.py
+++ b/test/test_PCSC.py
@@ -1,23 +1,18 @@
-import unittest
-from smartcard.System import readers
 from smartcard.scard import *
 
 
-class TestPCSC(unittest.TestCase):
+def test_low_level():
+    hresult, hcontext = SCardEstablishContext(SCARD_SCOPE_USER)
+    assert hresult in (SCARD_S_SUCCESS, SCARD_E_NO_SERVICE)
 
-    def test_low_level(self):
-        hresult, hcontext = SCardEstablishContext(SCARD_SCOPE_USER)
-        self.assertIn(hresult, [SCARD_S_SUCCESS, SCARD_E_NO_SERVICE])
+    if hresult == SCARD_E_NO_SERVICE:
+        return
 
-        if hresult == SCARD_E_NO_SERVICE:
-            return
+    hresult, _ = SCardListReaders(hcontext, [])
+    assert hresult in (SCARD_S_SUCCESS, SCARD_E_NO_READERS_AVAILABLE)
 
-        hresult, readers = SCardListReaders(hcontext, [])
-        self.assertIn(hresult, [SCARD_S_SUCCESS,
-                                SCARD_E_NO_READERS_AVAILABLE])
+    # the computer we are using may not have a reader connected
+    # so we can't do much
 
-        # the computer we are using may not have a reader connected
-        # so we can't do much
-
-        hresult = SCardReleaseContext(hcontext)
-        self.assertEqual(hresult, SCARD_S_SUCCESS)
+    hresult = SCardReleaseContext(hcontext)
+    assert hresult == SCARD_S_SUCCESS

--- a/test/test_PCSCExceptions.py
+++ b/test/test_PCSCExceptions.py
@@ -1,132 +1,162 @@
-# -*- coding: utf-8 -*-
-
-# to execute:
-# $ cd test
-# $ python -m unittest
-
-import unittest
-from smartcard.pcsc.PCSCExceptions import *
-from smartcard.scard import *
 import platform
 
+from smartcard.pcsc.PCSCExceptions import *
+from smartcard.scard import *
 
-class TestUtil(unittest.TestCase):
 
-    def test_ListReadersException(self):
-        exc = ListReadersException(0)
-        self.assertEqual(exc.hresult, 0)
-        text = str(exc)
-        if platform.system() == 'Windows':
-            expected = "Failed to list readers: The operation completed successfully.  (0x00000000)"
-        else:
-            expected = "Failed to list readers: Command successful. (0x00000000)"
-        self.assertEqual(text, expected)
+def test_list_readers_exception():
+    exc = ListReadersException(0)
+    assert exc.hresult == 0
+    text = str(exc)
+    if platform.system() == "Windows":
+        expected = (
+            "Failed to list readers: "
+            "The operation completed successfully.  (0x00000000)"
+        )
+    else:
+        expected = "Failed to list readers: Command successful. (0x00000000)"
+    assert text == expected
 
-        exc = ListReadersException(0x42)
-        self.assertEqual(exc.hresult, 0x42)
-        text = str(exc)
-        if platform.system() == 'Windows':
-            expected = "Failed to list readers: The network resource type is not correct.  (0x00000042)"
-        else:
-            expected = "Failed to list readers: Unknown error: 0x00000042 (0x00000042)"
-        macos_bug_expected = expected.replace("Unknown", "Unkown")
-        self.assertIn(text, [expected, macos_bug_expected])
+    exc = ListReadersException(0x42)
+    assert exc.hresult == 0x42
+    text = str(exc)
+    if platform.system() == "Windows":
+        expected = (
+            "Failed to list readers: "
+            "The network resource type is not correct.  (0x00000042)"
+        )
+    else:
+        expected = "Failed to list readers: Unknown error: 0x00000042 (0x00000042)"
+    macos_bug_expected = expected.replace("Unknown", "Unkown")
+    assert text in (expected, macos_bug_expected)
 
-        exc = ListReadersException(SCARD_S_SUCCESS)
-        self.assertEqual(exc.hresult, 0)
+    exc = ListReadersException(SCARD_S_SUCCESS)
+    assert exc.hresult == 0
 
-        exc = ListReadersException(SCARD_E_NO_SERVICE)
-        self.assertEqual(exc.hresult, SCARD_E_NO_SERVICE)
-        text = str(exc)
-        if platform.system() == 'Windows':
-            expected = "Failed to list readers: The Smart Card Resource Manager is not running.  (0x8010001D)"
-        else:
-            expected = "Failed to list readers: Service not available. (0x8010001D)"
-        self.assertEqual(text, expected)
+    exc = ListReadersException(SCARD_E_NO_SERVICE)
+    assert exc.hresult == SCARD_E_NO_SERVICE
+    text = str(exc)
+    if platform.system() == "Windows":
+        expected = (
+            "Failed to list readers: "
+            "The Smart Card Resource Manager is not running.  (0x8010001D)"
+        )
+    else:
+        expected = "Failed to list readers: Service not available. (0x8010001D)"
+    assert text == expected
 
-    def test_EstablishContextException(self):
-        exc = EstablishContextException(SCARD_E_NO_SERVICE)
-        self.assertEqual(exc.hresult, SCARD_E_NO_SERVICE)
-        text = str(exc)
-        if platform.system() == 'Windows':
-            expected = "Failed to establish context: The Smart Card Resource Manager is not running.  (0x8010001D)"
-        else:
-            expected = "Failed to establish context: Service not available. (0x8010001D)"
-        self.assertEqual(text, expected)
 
-    def test_IntroduceReaderException(self):
-        exc = IntroduceReaderException(SCARD_E_DUPLICATE_READER, "foobar")
-        self.assertEqual(exc.hresult, SCARD_E_DUPLICATE_READER)
-        text = str(exc)
-        if platform.system() == 'Windows':
-            expected = "Failed to introduce a new reader: foobar: The reader driver did not produce a unique reader name.  (0x8010001B)"
-        else:
-            expected = "Failed to introduce a new reader: foobar: Reader already exists. (0x8010001B)"
-        self.assertEqual(text, expected)
+def test_establish_context_exception():
+    exc = EstablishContextException(SCARD_E_NO_SERVICE)
+    assert exc.hresult == SCARD_E_NO_SERVICE
+    text = str(exc)
+    if platform.system() == "Windows":
+        expected = (
+            "Failed to establish context: "
+            "The Smart Card Resource Manager is not running.  (0x8010001D)"
+        )
+    else:
+        expected = "Failed to establish context: Service not available. (0x8010001D)"
+    assert text == expected
 
-    def test_RemoveReaderFromGroupException(self):
-        exc = RemoveReaderFromGroupException(SCARD_E_INVALID_HANDLE,
-            "readername", "readergroup")
-        self.assertEqual(exc.hresult, SCARD_E_INVALID_HANDLE)
-        text = str(exc)
-        if platform.system() == 'Windows':
-            expected = "Failed to remove reader: readername from group: readergroup: The supplied handle was invalid.  (0x80100003)"
-        else:
-            expected = "Failed to remove reader: readername from group: readergroup: Invalid handle. (0x80100003)"
-        self.assertEqual(text, expected)
 
-    def test_AddReaderToGroupException(self):
-        exc = AddReaderToGroupException(SCARD_E_INVALID_HANDLE,
-                "reader", "group")
-        self.assertEqual(exc.hresult, SCARD_E_INVALID_HANDLE)
-        text = str(exc)
-        if platform.system() == 'Windows':
-            expected = "Failed to add reader: reader to group: group: The supplied handle was invalid.  (0x80100003)"
-        else:
-            expected = "Failed to add reader: reader to group: group: Invalid handle. (0x80100003)"
-        self.assertEqual(text, expected)
+def test_introduce_reader_exception():
+    exc = IntroduceReaderException(SCARD_E_DUPLICATE_READER, "foobar")
+    assert exc.hresult == SCARD_E_DUPLICATE_READER
+    text = str(exc)
+    if platform.system() == "Windows":
+        expected = (
+            "Failed to introduce a new reader: foobar: "
+            "The reader driver did not produce a unique reader name.  (0x8010001B)"
+        )
+    else:
+        expected = (
+            "Failed to introduce a new reader: foobar: "
+            "Reader already exists. (0x8010001B)"
+        )
+    assert text == expected
 
-    def test_ReleaseContextException(self):
-        exc = ReleaseContextException(SCARD_E_INVALID_HANDLE)
-        self.assertEqual(exc.hresult, SCARD_E_INVALID_HANDLE)
-        text = str(exc)
-        if platform.system() == 'Windows':
-            expected = "Failed to release context: The supplied handle was invalid.  (0x80100003)"
-        else:
-            expected = "Failed to release context: Invalid handle. (0x80100003)"
-        self.assertEqual(text, expected)
 
-    def test_BaseSCardException(self):
-        exc = BaseSCardException(SCARD_E_UNKNOWN_READER)
-        self.assertEqual(exc.hresult, SCARD_E_UNKNOWN_READER)
-        text = str(exc)
-        if platform.system() == 'Windows':
-            expected = "scard exception: The specified reader name is not recognized.  (0x80100009)"
-        else:
-            expected = "scard exception: Unknown reader specified. (0x80100009)"
-        self.assertEqual(text, expected)
+def test_remove_reader_from_group_exception():
+    exc = RemoveReaderFromGroupException(
+        SCARD_E_INVALID_HANDLE, "readername", "readergroup"
+    )
+    assert exc.hresult == SCARD_E_INVALID_HANDLE
+    text = str(exc)
+    if platform.system() == "Windows":
+        expected = (
+            "Failed to remove reader: readername from group: readergroup: "
+            "The supplied handle was invalid.  (0x80100003)"
+        )
+    else:
+        expected = (
+            "Failed to remove reader: readername from group: readergroup: "
+            "Invalid handle. (0x80100003)"
+        )
+    assert text == expected
 
-        exc = BaseSCardException(hresult=-1)
-        self.assertEqual(exc.hresult, -1)
-        text = str(exc)
-        expected = "scard exception"
-        self.assertEqual(text, expected)
 
-        exc = BaseSCardException(hresult=-1, message="foo bar")
-        self.assertEqual(exc.hresult, -1)
-        text = str(exc)
-        expected = "foo bar"
-        self.assertEqual(text, expected)
+def test_add_reader_to_group_exception():
+    exc = AddReaderToGroupException(SCARD_E_INVALID_HANDLE, "reader", "group")
+    assert exc.hresult == SCARD_E_INVALID_HANDLE
+    text = str(exc)
+    if platform.system() == "Windows":
+        expected = (
+            "Failed to add reader: reader to group: group: "
+            "The supplied handle was invalid.  (0x80100003)"
+        )
+    else:
+        expected = (
+            "Failed to add reader: reader to group: group: "
+            "Invalid handle. (0x80100003)"
+        )
+    assert text == expected
 
-        exc= BaseSCardException(message="foo", hresult=SCARD_E_NOT_TRANSACTED)
-        self.assertEqual(exc.hresult, SCARD_E_NOT_TRANSACTED)
-        text = str(exc)
-        if platform.system() == 'Windows':
-            expected = "An attempt was made to end a non-existent transaction. "
-        else:
-            expected = "Transaction failed."
-        expected = "foo: " + expected + " (0x80100016)"
-        self.assertEqual(text, expected)
 
-if __name__ == '__main__':
-    unittest.main()
+def test_release_context_exception():
+    exc = ReleaseContextException(SCARD_E_INVALID_HANDLE)
+    assert exc.hresult == SCARD_E_INVALID_HANDLE
+    text = str(exc)
+    if platform.system() == "Windows":
+        expected = (
+            "Failed to release context: The supplied handle was invalid.  (0x80100003)"
+        )
+    else:
+        expected = "Failed to release context: Invalid handle. (0x80100003)"
+    assert text == expected
+
+
+def test_base_scard_exception():
+    exc = BaseSCardException(SCARD_E_UNKNOWN_READER)
+    assert exc.hresult == SCARD_E_UNKNOWN_READER
+    text = str(exc)
+    if platform.system() == "Windows":
+        expected = (
+            "scard exception: "
+            "The specified reader name is not recognized.  (0x80100009)"
+        )
+    else:
+        expected = "scard exception: Unknown reader specified. (0x80100009)"
+    assert text == expected
+
+    exc = BaseSCardException(hresult=-1)
+    assert exc.hresult == -1
+    text = str(exc)
+    expected = "scard exception"
+    assert text == expected
+
+    exc = BaseSCardException(hresult=-1, message="foo bar")
+    assert exc.hresult == -1
+    text = str(exc)
+    expected = "foo bar"
+    assert text == expected
+
+    exc = BaseSCardException(message="foo", hresult=SCARD_E_NOT_TRANSACTED)
+    assert exc.hresult == SCARD_E_NOT_TRANSACTED
+    text = str(exc)
+    if platform.system() == "Windows":
+        expected = "An attempt was made to end a non-existent transaction. "
+    else:
+        expected = "Transaction failed."
+    expected = "foo: " + expected + " (0x80100016)"
+    assert text == expected

--- a/test/test_SCardGetErrorMessage.py
+++ b/test/test_SCardGetErrorMessage.py
@@ -1,38 +1,29 @@
-# -*- coding: utf-8 -*-
-
-# to execute:
-# $ cd test
-# $ python -m unittest
-
-import unittest
-from smartcard.scard import SCardGetErrorMessage
-from smartcard.scard import SCARD_S_SUCCESS, SCARD_F_INTERNAL_ERROR
 import platform
 
-
-class TestError(unittest.TestCase):
-
-    def test_SCardGetErrorMessage(self):
-        res = SCardGetErrorMessage(SCARD_S_SUCCESS)
-
-        # do not test on Windows
-        # the error messages are different and localized
-        if platform.system() == 'Windows':
-            return
-
-        expected = "Command successful."
-        self.assertEqual(res, expected)
-
-        res = SCardGetErrorMessage(SCARD_F_INTERNAL_ERROR)
-        expected = "Internal error."
-        self.assertEqual(res, expected)
-
-        res = SCardGetErrorMessage(1)
-        expected = "Unknown error: 0x00000001"
-        # macOS bug not yet fixed
-        macos_bug_expected = "Unkown error: 0x00000001"
-        self.assertIn(res, [expected, macos_bug_expected])
+from smartcard.scard import (
+    SCARD_F_INTERNAL_ERROR,
+    SCARD_S_SUCCESS,
+    SCardGetErrorMessage,
+)
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_scard_get_error_message():
+    res = SCardGetErrorMessage(SCARD_S_SUCCESS)
+
+    # do not test on Windows
+    # the error messages are different and localized
+    if platform.system() == "Windows":
+        return
+
+    expected = "Command successful."
+    assert res == expected
+
+    res = SCardGetErrorMessage(SCARD_F_INTERNAL_ERROR)
+    expected = "Internal error."
+    assert res == expected
+
+    res = SCardGetErrorMessage(1)
+    expected = "Unknown error: 0x00000001"
+    # macOS bug not yet fixed
+    macos_bug_expected = "Unkown error: 0x00000001"
+    assert res in (expected, macos_bug_expected)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,154 +1,165 @@
-# -*- coding: utf-8 -*-
+import pytest
 
-# to execute:
-# $ cd test
-# $ python -m unittest
-
-import unittest
 from smartcard.util import *
 
 
-class TestUtil(unittest.TestCase):
+def test_to_bytes():
+    data_in = "3B 65 00 00 9C 11 01 01 03"
+    data_out = [59, 101, 0, 0, 156, 17, 1, 1, 3]
+    assert toBytes(data_in) == data_out
 
-    def test_toBytes(self):
-        data_in = "3B 65 00 00 9C 11 01 01 03"
-        data_out = [59, 101, 0, 0, 156, 17, 1, 1, 3]
-        self.assertEqual(toBytes(data_in), data_out)
+    data_in = "3B6500009C11010103"
+    assert toBytes(data_in) == data_out
 
-        data_in = "3B6500009C11010103"
-        self.assertEqual(toBytes(data_in), data_out)
+    data_in = "3B6500   009C1101  0103"
+    assert toBytes(data_in) == data_out
 
-        data_in = "3B6500   009C1101  0103"
-        self.assertEqual(toBytes(data_in), data_out)
+    data_in = """
+                3B 65 00
+                00 9C 11 01
+                01 03
+              """
+    assert toBytes(data_in) == data_out
 
-        data_in = '''
-                    3B 65 00
-                    00 9C 11 01
-                    01 03
-                  '''
-        self.assertEqual(toBytes(data_in), data_out)
-
-        data_in = "zz"
-        with self.assertRaises(TypeError):
-            toBytes(data_in)
-
-    def test_padd(self):
-        data_in = toBytes("3B 65 00 00 9C 11 01 01 03")
-        old_data_in = list(data_in)
-        data_out = [0x3B, 0x65, 0, 0, 0x9C, 0x11, 1, 1, 3,
-                    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
-        self.assertEqual(padd(data_in, 16), data_out)
-        self.assertEqual(data_in, old_data_in)
-
-        self.assertEqual(padd(data_in, 4), data_in)
-
-    def test_toASCIIBytes(self):
-        data_in = "Number 101"
-        data_out = [0x4E, 0x75, 0x6D, 0x62, 0x65, 0x72, 0x20, 0x31, 0x30, 0x31]
-        self.assertEqual(toASCIIBytes(data_in), data_out)
-
-    def test_toASCIIString(self):
-        data_in = [0x4E, 0x75, 0x6D, 0x62, 0x65, 0x72, 0x20, 0x31, 0x30, 0x31]
-        data_out = "Number 101"
-        self.assertEqual(toASCIIString(data_in), data_out)
-
-        data_in = [0x01, 0x20, 0x80, 0x7E, 0xF0]
-        data_out = ". .~."
-        self.assertEqual(toASCIIString(data_in), data_out)
-
-    def test_toGSM3_38Bytes(self):
-        data_in = "@Pascal"
-        data_out = [0x00, 0x50, 0x61, 0x73, 0x63, 0x61, 0x6C]
-        self.assertEqual(toGSM3_38Bytes(data_in), data_out)
-
-        data_in = "@ùPascal"
-        data_out = [0x00, 0x06, 0x50, 0x61, 0x73, 0x63, 0x61, 0x6C]
-        self.assertEqual(toGSM3_38Bytes(data_in), data_out)
-
-        data_in = "@ùPascal".encode('iso8859-1')
-        data_out = [0x00, 0x06, 0x50, 0x61, 0x73, 0x63, 0x61, 0x6C]
-        self.assertEqual(toGSM3_38Bytes(data_in), data_out)
-
-        data_in = "1234"
-        data_out = [0x31, 0x32, 0x33, 0x34]
-        self.assertEqual(toGSM3_38Bytes(data_in), data_out)
-
-    def test_toHexString(self):
-        data_in = []
-        data_out = ""
-        self.assertEqual(toHexString(data_in), data_out)
-
-        data_in = 42
-        with self.assertRaises(TypeError):
-            toHexString(data_in)
-
-        data_in = [0x3B, 0x65, 0x00, 0x00, 0x9C, 0x11, 0x01, 0x01, 0x03]
-        data_out = "3B 65 00 00 9C 11 01 01 03"
-        self.assertEqual(toHexString(data_in), data_out)
-
-        data_out = "3B, 65, 00, 00, 9C, 11, 01, 01, 03"
-        self.assertEqual(toHexString(data_in, COMMA), data_out)
-
-        data_out = "0x3B 0x65 0x00 0x00 0x9C 0x11 0x01 0x01 0x03"
-        self.assertEqual(toHexString(data_in, HEX), data_out)
-
-        data_out = "0x3B, 0x65, 0x00, 0x00, 0x9C, 0x11, 0x01, 0x01, 0x03"
-        self.assertEqual(toHexString(data_in, HEX | COMMA), data_out)
-
-        data_out = "0X3B 0X65 0X00 0X00 0X9C 0X11 0X01 0X01 0X03"
-        self.assertEqual(toHexString(data_in, HEX | UPPERCASE), data_out)
-
-        data_out = "0X3B, 0X65, 0X00, 0X00, 0X9C, 0X11, 0X01, 0X01, 0X03"
-        self.assertEqual(toHexString(data_in, HEX | UPPERCASE | COMMA),
-                         data_out)
-
-        data_out = "3B6500009C11010103"
-        self.assertEqual(toHexString(data_in, PACK), data_out)
-
-        data_out = "3B,65,00,00,9C,11,01,01,03"
-        self.assertEqual(toHexString(data_in, COMMA | PACK), data_out)
-
-        data_out = "0x3B0x650x000x000x9C0x110x010x010x03"
-        self.assertEqual(toHexString(data_in, HEX | PACK), data_out)
-
-        data_out = "0x3B,0x65,0x00,0x00,0x9C,0x11,0x01,0x01,0x03"
-        self.assertEqual(toHexString(data_in, HEX | COMMA | PACK), data_out)
-
-        data_out = "0X3B0X650X000X000X9C0X110X010X010X03"
-        self.assertEqual(toHexString(data_in, HEX | UPPERCASE | PACK),
-                         data_out)
-
-        data_out = "0X3B,0X65,0X00,0X00,0X9C,0X11,0X01,0X01,0X03"
-        self.assertEqual(toHexString(data_in, HEX | UPPERCASE | COMMA |
-                                     PACK), data_out)
-
-        with self.assertRaises(TypeError):
-            toHexString("foo")
-
-    def test_HexListToBinString(self):
-        data_in = [1, 2, 3]
-        data_out = "\x01\x02\x03"
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(HexListToBinString(data_in), data_out)
-
-    def test_BinStringToHexList(self):
-        data_in = "\x01\x02\x03"
-        data_out = [1, 2, 3]
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(BinStringToHexList(data_in), data_out)
-
-    def test_hl2bs(self):
-        data_in = [78, 117, 109, 98, 101, 114, 32, 49, 48, 49]
-        data_out = 'Number 101'
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(hl2bs(data_in), data_out)
-
-    def test_bs2hl(self):
-        data_in = 'Number 101'
-        data_out = [78, 117, 109, 98, 101, 114, 32, 49, 48, 49]
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(bs2hl(data_in), data_out)
+    data_in = "zz"
+    with pytest.raises(TypeError):
+        toBytes(data_in)
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_padd():
+    data_in = toBytes("3B 65 00 00 9C 11 01 01 03")
+    old_data_in = list(data_in)
+    data_out = [
+        0x3B,
+        0x65,
+        0,
+        0,
+        0x9C,
+        0x11,
+        1,
+        1,
+        3,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+    ]
+    assert padd(data_in, 16) == data_out
+    assert data_in == old_data_in
+
+    assert padd(data_in, 4) == data_in
+
+
+def test_to_ascii_bytes():
+    data_in = "Number 101"
+    data_out = [0x4E, 0x75, 0x6D, 0x62, 0x65, 0x72, 0x20, 0x31, 0x30, 0x31]
+    assert toASCIIBytes(data_in) == data_out
+
+
+def test_to_ascii_string():
+    data_in = [0x4E, 0x75, 0x6D, 0x62, 0x65, 0x72, 0x20, 0x31, 0x30, 0x31]
+    data_out = "Number 101"
+    assert toASCIIString(data_in) == data_out
+
+    data_in = [0x01, 0x20, 0x80, 0x7E, 0xF0]
+    data_out = ". .~."
+    assert toASCIIString(data_in) == data_out
+
+
+def test_to_gsm3_38_bytes():
+    data_in = "@Pascal"
+    data_out = [0x00, 0x50, 0x61, 0x73, 0x63, 0x61, 0x6C]
+    assert toGSM3_38Bytes(data_in) == data_out
+
+    data_in = "@ùPascal"
+    data_out = [0x00, 0x06, 0x50, 0x61, 0x73, 0x63, 0x61, 0x6C]
+    assert toGSM3_38Bytes(data_in) == data_out
+
+    data_in = "@ùPascal".encode("iso8859-1")
+    data_out = [0x00, 0x06, 0x50, 0x61, 0x73, 0x63, 0x61, 0x6C]
+    assert toGSM3_38Bytes(data_in) == data_out
+
+    data_in = "1234"
+    data_out = [0x31, 0x32, 0x33, 0x34]
+    assert toGSM3_38Bytes(data_in) == data_out
+
+
+def test_to_hex_string():
+    data_in = []
+    data_out = ""
+    assert toHexString(data_in) == data_out
+
+    data_in = 42
+    with pytest.raises(TypeError):
+        toHexString(data_in)
+
+    data_in = [0x3B, 0x65, 0x00, 0x00, 0x9C, 0x11, 0x01, 0x01, 0x03]
+    data_out = "3B 65 00 00 9C 11 01 01 03"
+    assert toHexString(data_in) == data_out
+
+    data_out = "3B, 65, 00, 00, 9C, 11, 01, 01, 03"
+    assert toHexString(data_in, COMMA) == data_out
+
+    data_out = "0x3B 0x65 0x00 0x00 0x9C 0x11 0x01 0x01 0x03"
+    assert toHexString(data_in, HEX) == data_out
+
+    data_out = "0x3B, 0x65, 0x00, 0x00, 0x9C, 0x11, 0x01, 0x01, 0x03"
+    assert toHexString(data_in, HEX | COMMA) == data_out
+
+    data_out = "0X3B 0X65 0X00 0X00 0X9C 0X11 0X01 0X01 0X03"
+    assert toHexString(data_in, HEX | UPPERCASE) == data_out
+
+    data_out = "0X3B, 0X65, 0X00, 0X00, 0X9C, 0X11, 0X01, 0X01, 0X03"
+    assert toHexString(data_in, HEX | UPPERCASE | COMMA) == data_out
+
+    data_out = "3B6500009C11010103"
+    assert toHexString(data_in, PACK) == data_out
+
+    data_out = "3B,65,00,00,9C,11,01,01,03"
+    assert toHexString(data_in, COMMA | PACK) == data_out
+
+    data_out = "0x3B0x650x000x000x9C0x110x010x010x03"
+    assert toHexString(data_in, HEX | PACK) == data_out
+
+    data_out = "0x3B,0x65,0x00,0x00,0x9C,0x11,0x01,0x01,0x03"
+    assert toHexString(data_in, HEX | COMMA | PACK) == data_out
+
+    data_out = "0X3B0X650X000X000X9C0X110X010X010X03"
+    assert toHexString(data_in, HEX | UPPERCASE | PACK) == data_out
+
+    data_out = "0X3B,0X65,0X00,0X00,0X9C,0X11,0X01,0X01,0X03"
+    assert toHexString(data_in, HEX | UPPERCASE | COMMA | PACK) == data_out
+
+    with pytest.raises(TypeError):
+        toHexString("foo")
+
+
+def test_hex_list_to_bin_string():
+    data_in = [1, 2, 3]
+    data_out = "\x01\x02\x03"
+    with pytest.warns(DeprecationWarning):
+        assert HexListToBinString(data_in) == data_out
+
+
+def test_bin_string_to_hex_list():
+    data_in = "\x01\x02\x03"
+    data_out = [1, 2, 3]
+    with pytest.warns(DeprecationWarning):
+        assert BinStringToHexList(data_in) == data_out
+
+
+def test_hl2bs():
+    data_in = [78, 117, 109, 98, 101, 114, 32, 49, 48, 49]
+    data_out = "Number 101"
+    with pytest.warns(DeprecationWarning):
+        assert hl2bs(data_in) == data_out
+
+
+def test_bs2hl():
+    data_in = "Number 101"
+    data_out = [78, 117, 109, 98, 101, 114, 32, 49, 48, 49]
+    with pytest.warns(DeprecationWarning):
+        assert bs2hl(data_in) == data_out


### PR DESCRIPTION
This PR introduces the following changes:

* Migrate the test suite to use pytest features
* Address a duplicated test name in `test_Exceptions.py`: `test_ListReadersException`.
  The duplicate tests have been merged.

Most of this work was mechanical:

* Remove `unittest.TestCase` subclass definition lines
* De-dent the class methods
* Remove references to `self` in the function parameters
* Use regular expressions to search and replace assertions:
  * `self.assertEqual(x, y)` -> `assert x == y`
  * `self.assertRaises` -> `pytest.raises`
  * `self.assertFalse(x)` -> `assert x is False`
  * `self.assertIn(x, y)` -> `assert x in y`

Some long strings were wrapped to prepare for the possibility of using code formatters in the future.

STDOUT capture code was replaced with the pytest `capsys` fixture, which simplified the code in `test_ATR.py`.

----

This PR prepares for the possibility of consolidating the live tests in `src/smartcard/test/` together with the overall test suite, and using pytest features to control whether the live tests run or not.

This is only a possibility, not a guarantee, but migrating from unittest code to pytest code helps pave the way.