### PR TITLE
Add a pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,51 @@
+ci:
+  autoupdate_schedule: "quarterly"
+
+default_language_version:
+  python: "python3.12"
+
+repos:
+  - repo: "meta"
+    hooks:
+      - id: "check-hooks-apply"
+      - id: "check-useless-excludes"
+
+  - repo: "https://github.com/pre-commit/pre-commit-hooks"
+    rev: "v4.6.0"
+    hooks:
+      - id: "check-added-large-files"
+      - id: "check-merge-conflict"
+      - id: "check-yaml"
+      - id: "end-of-file-fixer"
+      - id: "mixed-line-ending"
+        args:
+          - "--fix=lf"
+      - id: "trailing-whitespace"
+
+  - repo: "https://github.com/asottile/pyupgrade"
+    rev: "v3.17.0"
+    hooks:
+      - id: "pyupgrade"
+        name: "Enforce Python 3.9+ idioms"
+        args:
+          - "--py39-plus"
+
+  - repo: "https://github.com/psf/black-pre-commit-mirror"
+    rev: "24.8.0"
+    hooks:
+      - id: "black"
+
+  - repo: "https://github.com/pycqa/isort"
+    rev: "5.13.2"
+    hooks:
+      - id: "isort"
+
+  - repo: "https://github.com/python-jsonschema/check-jsonschema"
+    rev: "0.29.2"
+    hooks:
+      - id: "check-github-workflows"
+
+  - repo: "https://github.com/rhysd/actionlint"
+    rev: "v1.7.2"
+    hooks:
+      - id: "actionlint"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,13 @@ requires = ["setuptools","swig"]
 build-backend = "setuptools.build_meta"
 
 
+# isort
+# -----
+
+[tool.isort]
+profile = "black"
+
+
 # pydoctor
 # --------
 


### PR DESCRIPTION
This PR introduces a pre-commit configuration file.

To use pre-commit, install the tool, perhaps using pipx or perhaps adding it to a virtual environment you use for the repository.

```bash
pipx install pre-commit
```

Then, run this command to install the tool as a git pre-commit hook:

```bash
pre-commit install
```

Then, whenever you modify a file (or files) in the repository, pre-commit will run the configured hooks against the modified files. If the files are modified by the hooks, the git commit will fail and you'll have an opportunity to review and stage the changes made by the hooks.

----

To format the files in this repo, you can run this command (but be aware that pyupgrade will need to be run three times because there is a specific line in `ClassLoader.py` that pyupgrade incrementally updates).

```
pre-commit run -a
pre-commit run -a
pre-commit run -a
```

----

I _strongly_ recommend enabling [pre-commit.ci](https://pre-commit.ci/), which -- like coveralls -- will automatically run an additional action against incoming PRs. The difference is that pre-commit.ci will automatically push an additional commit to the PR if one of the modified files doesn't conform to the code format rules.