### PR TITLE
Add a Dependabot config to maintain GitHub action versions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
This PR introduces a Dependabot configuration.

If accepted, Dependabot will submit at most one PR each month to update GitHub action versions (like `actions/checkout` and `actions/setup-python`) if there are any updates available.

This will help ensure that the action versions do not become stale over time.