### PR TITLE
Update HTTP URLs, and resolve most redirects

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -61,7 +61,7 @@ pip install pyscard
 Installing on windows from the source distribution
 ---------------------------------------------------
 
-1. you will need [swig](http://www.swig.org), and a C compiler.
+1. you will need [swig](https://www.swig.org/), and a C compiler.
 
 You can install swig using:
 
@@ -97,7 +97,7 @@ Installation on GNU/Linux or macOS
 Installing on GNU/Linux or macOS from the source distribution
 -------------------------------------------------------------
 
-1. you will need gcc, swig (http://www.swig.org), and pcsc-lite
+1. you will need gcc, swig (https://www.swig.org/), and pcsc-lite
 (https://pcsclite.apdu.fr/)
 
 2. download the source distribution

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 """Setup file for setuptools
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com
@@ -142,7 +142,7 @@ kw = {'name': "pyscard",
       }
 
 # FIXME Sourceforge downloads are unauthenticated, migrate to PyPI
-kw['download_url'] = ('http://sourceforge.net/projects/%(name)s/files'
+kw['download_url'] = ('https://sourceforge.net/projects/%(name)s/files'
                       '/%(name)s/%(name)s%%20%(version)s'
                       '/%(name)s-%(version)s.tar.gz/download' % kw)
 

--- a/src/smartcard/ATR.py
+++ b/src/smartcard/ATR.py
@@ -1,6 +1,6 @@
 """ATR class managing some of the Answer To Reset content.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/AbstractCardRequest.py
+++ b/src/smartcard/AbstractCardRequest.py
@@ -1,6 +1,6 @@
 """AbstractCardRequest class.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Card.py
+++ b/src/smartcard/Card.py
@@ -1,6 +1,6 @@
 """Card class.
 
-__author__ = "gemalto http://www.gemalto.com"
+__author__ = "gemalto https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/CardConnection.py
+++ b/src/smartcard/CardConnection.py
@@ -1,7 +1,7 @@
 """The CardConnection abstract class manages connections with a card and
 apdu transmission.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/CardConnectionDecorator.py
+++ b/src/smartcard/CardConnectionDecorator.py
@@ -2,7 +2,7 @@
 abstract class, and allows dynamic addition of features to the
 CardConnection, e.g. implementing a secure channel..
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/CardConnectionEvent.py
+++ b/src/smartcard/CardConnectionEvent.py
@@ -1,7 +1,7 @@
 """The CardConnectionEvent is sent to CardConnectionObserver objects
 when a CardConnection event occurs.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/CardConnectionObserver.py
+++ b/src/smartcard/CardConnectionObserver.py
@@ -3,7 +3,7 @@
 CardConnectionObserver is a base class for objects that are to be notified
 upon CardConnection events.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/CardMonitoring.py
+++ b/src/smartcard/CardMonitoring.py
@@ -6,7 +6,7 @@ upon smart card insertion/removal.
 CardMonitor is a singleton object notifying registered CardObservers
 upon reader insertion/removal.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/CardRequest.py
+++ b/src/smartcard/CardRequest.py
@@ -1,6 +1,6 @@
 """Smartcard CardRequest.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/CardService.py
+++ b/src/smartcard/CardService.py
@@ -8,7 +8,7 @@ card service is almost always smart card operating system specific.
 The card service performs its specific smart card functionality by accessing
 the smartcard with a CardConnection.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/CardType.py
+++ b/src/smartcard/CardType.py
@@ -1,6 +1,6 @@
 """Abstract CarType.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/ClassLoader.py
+++ b/src/smartcard/ClassLoader.py
@@ -6,7 +6,7 @@ or within an interface.
 Source: Robert Brewer at the Python Cookbook:
 http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/223972
 
-License: PSF license (http://docs.python.org/license.html).
+License: PSF license (https://docs.python.org/license.html).
 """
 
 

--- a/src/smartcard/Examples/framework/sample_ATR.py
+++ b/src/smartcard/Examples/framework/sample_ATR.py
@@ -2,7 +2,7 @@
 """
 Sample script for the smartcard.ATR utility class.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2009 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/framework/sample_CardConnectionDecorator.py
+++ b/src/smartcard/Examples/framework/sample_CardConnectionDecorator.py
@@ -2,7 +2,7 @@
 """
 Sample script that illustrates card connection decorators.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/framework/sample_ConsoleConnectionTracer.py
+++ b/src/smartcard/Examples/framework/sample_ConsoleConnectionTracer.py
@@ -2,7 +2,7 @@
 """
 Sample script that monitors card connection events.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/framework/sample_CustomCardType.py
+++ b/src/smartcard/Examples/framework/sample_CustomCardType.py
@@ -2,7 +2,7 @@
 """
 Sample script that demonstrates how to create a custom CardType.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/framework/sample_CustomErrorChecker.py
+++ b/src/smartcard/Examples/framework/sample_CustomErrorChecker.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 """Sample script for APDU error checking with a custom error checker.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/framework/sample_ErrorChecking.py
+++ b/src/smartcard/Examples/framework/sample_ErrorChecking.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 """Sample script for APDU error checking.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/framework/sample_ExclusiveCardConnection.py
+++ b/src/smartcard/Examples/framework/sample_ExclusiveCardConnection.py
@@ -2,7 +2,7 @@
 """
 Sample script that illustrates exclusive card connection decorators.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/framework/sample_MonitorCards.py
+++ b/src/smartcard/Examples/framework/sample_MonitorCards.py
@@ -2,7 +2,7 @@
 """
 Sample script that monitors smartcard insertion/removal.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/framework/sample_MonitorCardsAndTransmit.py
+++ b/src/smartcard/Examples/framework/sample_MonitorCardsAndTransmit.py
@@ -3,7 +3,7 @@
 Sample script that monitors smartcard insertion/removal and select
 DF_TELECOM on inserted cards
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/framework/sample_MonitorReaders.py
+++ b/src/smartcard/Examples/framework/sample_MonitorReaders.py
@@ -2,7 +2,7 @@
 """
 Sample script that monitors smartcard readers.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/framework/sample_TransmitCardObserver.py
+++ b/src/smartcard/Examples/framework/sample_TransmitCardObserver.py
@@ -3,7 +3,7 @@
 Sample script that monitors card insertions,
 connects to cards and transmit an apdu
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/framework/sample_apduTracerInterpreter.py
+++ b/src/smartcard/Examples/framework/sample_apduTracerInterpreter.py
@@ -2,7 +2,7 @@
 """
 Sample script that defines a custom card connection observer.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/framework/sample_toHexString.py
+++ b/src/smartcard/Examples/framework/sample_toHexString.py
@@ -2,7 +2,7 @@
 """
 Sample script to illustrate toHexString() utility method
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/scard-api/sample_getATR.py
+++ b/src/smartcard/Examples/scard-api/sample_getATR.py
@@ -2,7 +2,7 @@
 """
 Sample for python PCSC wrapper module: get card ATR in first pcsc reader
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/scard-api/sample_getAttrib.py
+++ b/src/smartcard/Examples/scard-api/sample_getAttrib.py
@@ -2,7 +2,7 @@
 """
 Sample for python PCSC wrapper module: List card attributes
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/scard-api/sample_getStatusChange.py
+++ b/src/smartcard/Examples/scard-api/sample_getStatusChange.py
@@ -2,7 +2,7 @@
 """
 Sample for python PCSC wrapper module: Detect card insertion/removal
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/scard-api/sample_listCards.py
+++ b/src/smartcard/Examples/scard-api/sample_listCards.py
@@ -2,7 +2,7 @@
 """
 Sample for python PCSC wrapper module: List cards introduced in the system
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/scard-api/sample_listInterfaces.py
+++ b/src/smartcard/Examples/scard-api/sample_listInterfaces.py
@@ -2,7 +2,7 @@
 """
 Sample for python PCSC wrapper module: List card interfaces
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/scard-api/sample_locateCards.py
+++ b/src/smartcard/Examples/scard-api/sample_locateCards.py
@@ -2,7 +2,7 @@
 """
 Sample for python PCSC wrapper module: Locate cards in the system
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/scard-api/sample_readerGroups.py
+++ b/src/smartcard/Examples/scard-api/sample_readerGroups.py
@@ -2,7 +2,7 @@
 """
 Sample for python PCSC wrapper module: illustrate reader groups functions
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/scard-api/sample_readers.py
+++ b/src/smartcard/Examples/scard-api/sample_readers.py
@@ -2,7 +2,7 @@
 """
 Sample for python PCSC wrapper module: List PCSC readers
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/scard-api/sample_selectDFTelecom.py
+++ b/src/smartcard/Examples/scard-api/sample_selectDFTelecom.py
@@ -2,7 +2,7 @@
 """
 Sample for python PCSC wrapper module: Select DF_TELECOM on a SIM card
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/scard-api/sample_transaction.py
+++ b/src/smartcard/Examples/scard-api/sample_transaction.py
@@ -2,7 +2,7 @@
 """
 Sample for python PCSC wrapper module: perform a simple transaction
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/simple/getATR.py
+++ b/src/smartcard/Examples/simple/getATR.py
@@ -2,7 +2,7 @@
 """
 Sample script that displays the ATR of inserted cards.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/simple/getATR_context.py
+++ b/src/smartcard/Examples/simple/getATR_context.py
@@ -2,7 +2,7 @@
 """
 Sample script that displays the ATR of inserted cards.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/simple/selectDF_TELECOM.py
+++ b/src/smartcard/Examples/simple/selectDF_TELECOM.py
@@ -2,7 +2,7 @@
 """
 Sample script that tries to select the DF_TELECOM on all inserted cards.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/wx/apdumanager/SampleAPDUManagerPanel.py
+++ b/src/smartcard/Examples/wx/apdumanager/SampleAPDUManagerPanel.py
@@ -2,7 +2,7 @@
 """
 Simple panel that defines a dialog to send APDUs to a card.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/wx/apdumanager/apdumanager.py
+++ b/src/smartcard/Examples/wx/apdumanager/apdumanager.py
@@ -2,7 +2,7 @@
 """
 Simple application to send APDUs to a card.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/wx/apdumanager/setup.py
+++ b/src/smartcard/Examples/wx/apdumanager/setup.py
@@ -3,7 +3,7 @@
 Setup script to build a standalone apdumanager.exe executable on windows
 using py2exe. Run: python.exe setup.py py2exe, to build executable file.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/wx/cardmonitor/cardmonitor.py
+++ b/src/smartcard/Examples/wx/cardmonitor/cardmonitor.py
@@ -2,7 +2,7 @@
 """
 Simple smart card monitoring application.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/wx/cardmonitor/setup.py
+++ b/src/smartcard/Examples/wx/cardmonitor/setup.py
@@ -3,7 +3,7 @@
 Setup script to build a standalone cardmonitor.exe executable on windows
 using py2exe. Run: python.exe setup.py py2exe, to build executable file.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/wx/pcscdiag/pcscdiag.py
+++ b/src/smartcard/Examples/wx/pcscdiag/pcscdiag.py
@@ -4,7 +4,7 @@ Example wxPython application that displays readers and inserted cards ATRs.
 This example displays a snapshot of the readers and cards, there is no
 automatic refresh of the readers and cards.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com
@@ -31,11 +31,11 @@ import smartcard.System
 import smartcard.util
 
 
-# wxPython GUI modules (http://www.wxpython.org)
+# wxPython GUI modules (https://www.wxpython.org/)
 try:
     import wx
 except ImportError:
-    print('You need wxpython (http://www.wxpython.org) ' + \
+    print('You need wxpython (https://www.wxpython.org/) ' + \
           'to run this sample from the source code!')
     print('press a key to continue')
     import msvcrt

--- a/src/smartcard/Examples/wx/readerviewer/readerviewer.py
+++ b/src/smartcard/Examples/wx/readerviewer/readerviewer.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 """Simple smart card reader monitoring application.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Examples/wx/readerviewer/setup.py
+++ b/src/smartcard/Examples/wx/readerviewer/setup.py
@@ -3,7 +3,7 @@
 Setup script to build a standalone readerviewer.exe executable on windows
 using py2exe. Run: python.exe setup.py py2exe, to build executable file.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Exceptions.py
+++ b/src/smartcard/Exceptions.py
@@ -2,7 +2,7 @@
 
 This module defines the exceptions raised by the smartcard module.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/ExclusiveConnectCardConnection.py
+++ b/src/smartcard/ExclusiveConnectCardConnection.py
@@ -1,6 +1,6 @@
 """CardConnectionDecorator that provides exclusive use of a card.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/ExclusiveTransmitCardConnection.py
+++ b/src/smartcard/ExclusiveTransmitCardConnection.py
@@ -1,6 +1,6 @@
 """Sample CardConnectionDecorator that provides exclusive transmit()
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Observer.py
+++ b/src/smartcard/Observer.py
@@ -1,6 +1,6 @@
 """
 from Thinking in Python, Bruce Eckel
-http://python-3-patterns-idioms-test.readthedocs.org/en/latest/Observer.html
+https://python-3-patterns-idioms-test.readthedocs.io/en/latest/Observer.html
 
 (c) Copyright 2008, Creative Commons Attribution-Share Alike 3.0.
 

--- a/src/smartcard/PassThruCardService.py
+++ b/src/smartcard/PassThruCardService.py
@@ -5,7 +5,7 @@ e.g.  a GSM file system or an Open Platform loader.  CardService is an
 abstract class from which concrete card services are derived.  A concrete
 card service is almost always smart card operating system specific
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/ReaderMonitoring.py
+++ b/src/smartcard/ReaderMonitoring.py
@@ -6,7 +6,7 @@ upon smartcard reader insertion/removal.
 ReaderMonitor is a singleton object notifying registered ReaderObservers
 upon reader insertion/removal.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Session.py
+++ b/src/smartcard/Session.py
@@ -1,7 +1,7 @@
 """
 Smartcard Session.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/Synchronization.py
+++ b/src/smartcard/Synchronization.py
@@ -1,6 +1,6 @@
 """
 from Thinking in Python, Bruce Eckel
-http://python-3-patterns-idioms-test.readthedocs.org/en/latest/Observer.html
+https://python-3-patterns-idioms-test.readthedocs.io/en/latest/Observer.html
 
 (c) Copyright 2008, Creative Commons Attribution-Share Alike 3.0.
 

--- a/src/smartcard/System.py
+++ b/src/smartcard/System.py
@@ -2,7 +2,7 @@
 
 Manages smartcard readers and reader groups.
 
-__author__ = "gemalto http://www.gemalto.com"
+__author__ = "gemalto https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/__init__.py
+++ b/src/smartcard/__init__.py
@@ -3,7 +3,7 @@
 The smartcard utility module provides classes and functions to
 access smartcards and readers.
 
-__author__ = "gemalto http://www.gemalto.com"
+__author__ = "gemalto https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/doc/index.rst
+++ b/src/smartcard/doc/index.rst
@@ -3,7 +3,7 @@ pyscard - Python for smart cards
 
 `pyscard - Python smart card library -
 <https://github.com/LudovicRousseau/pyscard>`_ is a Python module adding
-smart cards support to `Python <http://www.python.org/>`_ 3.9 and higher.
+smart cards support to `Python <https://www.python.org/>`_ 3.9 and higher.
 
 Download
 ********

--- a/src/smartcard/doc/user-guide.rst
+++ b/src/smartcard/doc/user-guide.rst
@@ -6,7 +6,7 @@ pyscard user's guide
 Copyright
 *********
 
-| Copyright 2001-2009 `Gemalto <http://www.gemalto.com/>`_
+| Copyright 2001-2009 `Gemalto <https://www.gemalto.com/>`_
 | Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com
 
 | Copyright 2007-2018
@@ -36,8 +36,8 @@ The pyscard smartcard library is a framework for building smart card
 aware applications in Python. The smartcard module is built on top of
 the PCSC API Python wrapper module.
 
-pyscard supports Windows 2000 and XP by using the `Microsoft Smart Card
-Base <http://msdn2.microsoft.com/en-us/library/aa374731.aspx#smart_card_functions>`_ components, and Linux and Mac OS X by using `PCSC-lite <http://pcsclite.alioth.debian.org/>`_.
+pyscard supports Windows operating systems via the `Microsoft Smart Card
+SDK <https://learn.microsoft.com/en-us/windows/win32/secauthn/authentication-functions#smart-card-functions>`_ components, and Linux and Mac OS X by using `PCSC-lite <https://pcsclite.apdu.fr/>`_.
 
 
 Smart Cards
@@ -59,14 +59,13 @@ the PC, often nowadays thru a USB port.
 The PCSC workgroup has defined a standard API to interface smart card
 and smart card readers to a PC. The resulting reference implementation
 on Linux and Mac OS X operating systems is `PC/SC-lite
-<http://pcsclite.alioth.debian.org/>`_. All windows operating systems
-also include out of the box smart card support, usually called `PCSC
-<http://msdn2.microsoft.com/en-us/library/aa374731.aspx#smart_card_functions>`_.
+<https://pcsclite.apdu.fr/>`_. All Windows operating systems
+also include out-of-the-box smart card support.
 
 The PCSC API is implemented in C language, and several bridges are
 provided to access the PCSC API from different languages such as java or
 visual basic. pyscard is a Python framework to develop smart card PC
-applications on Linux, Mac OS X and windows. pyscard lower layers
+applications on Linux, Mac OS X, and Windows. pyscard lower layers
 interface to the PCSC API to access the smart cards and smart card
 readers.
 
@@ -1400,7 +1399,7 @@ Smart card are security devices. As a result, smart card applications
 usually require some kind cryptography, for example to establish a
 secure channel with the smart card. One of the reference cryptographic
 modules for Python is `pycrypto
-<http://www.amk.ca/python/code/crypto.html>`_, the Python cryptographic
+<https://www.pycrypto.org/>`_, the Python cryptographic
 toolkit. This section shows briefly the basics of pycrypto to give you a
 quick start to include cryptography in your Python smart card
 applications.

--- a/src/smartcard/guid.py
+++ b/src/smartcard/guid.py
@@ -2,7 +2,7 @@
 
 Utility functions to handle GUIDs as strings or list of bytes
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/pcsc/PCSCCardConnection.py
+++ b/src/smartcard/pcsc/PCSCCardConnection.py
@@ -1,6 +1,6 @@
 """PCSCCardConnection class manages connections thru a PCSC reader.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/pcsc/PCSCCardRequest.py
+++ b/src/smartcard/pcsc/PCSCCardRequest.py
@@ -1,6 +1,6 @@
 """PCSC Smartcard request.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/pcsc/PCSCContext.py
+++ b/src/smartcard/pcsc/PCSCContext.py
@@ -1,6 +1,6 @@
 """PCSC context singleton.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/pcsc/PCSCExceptions.py
+++ b/src/smartcard/pcsc/PCSCExceptions.py
@@ -2,7 +2,7 @@
 
 This module defines the exceptions raised by the smartcard.pcsc modules.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/pcsc/PCSCReader.py
+++ b/src/smartcard/pcsc/PCSCReader.py
@@ -1,6 +1,6 @@
 """PCSCReader: concrete reader class for PCSC Readers
 
-__author__ = "gemalto http://www.gemalto.com"
+__author__ = "gemalto https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/pcsc/PCSCReaderGroups.py
+++ b/src/smartcard/pcsc/PCSCReaderGroups.py
@@ -1,6 +1,6 @@
 """PCSCReaderGroups organizes smartcard readers as groups.
 
-__author__ = "gemalto http://www.gemalto.com"
+__author__ = "gemalto https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/reader/Reader.py
+++ b/src/smartcard/reader/Reader.py
@@ -1,6 +1,6 @@
 """Smart card Reader abstract class.
 
-__author__ = "gemalto http://www.gemalto.com"
+__author__ = "gemalto https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/reader/ReaderFactory.py
+++ b/src/smartcard/reader/ReaderFactory.py
@@ -1,6 +1,6 @@
 """ReaderFactory: creates smartcard readers.
 
-__author__ = "gemalto http://www.gemalto.com"
+__author__ = "gemalto https://www.gemalto.com/"
 
 Factory pattern implementation borrowed from
 Thinking in Python, Bruce Eckel,

--- a/src/smartcard/reader/ReaderGroups.py
+++ b/src/smartcard/reader/ReaderGroups.py
@@ -1,6 +1,6 @@
 """ReaderGroups manages smart card reader in groups.
 
-__author__ = "gemalto http://www.gemalto.com"
+__author__ = "gemalto https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/scard/pyscard-reader.h
+++ b/src/smartcard/scard/pyscard-reader.h
@@ -1,6 +1,6 @@
 /*==============================================================================
 This file contains SCARD_ATTR attributes definitions taken from
-reader.h, in MUSCLE SmartCard Development ( http://www.linuxnet.com ).
+reader.h, in MUSCLE SmartCard Development ( https://muscle.apdu.fr/ ).
 It allows to build pyscard on Mac OS X without any dependency on the
 muscle source code.  Indeed, default Mac OS X does not contain reader.h
 as part of the PCSC.framework.

--- a/src/smartcard/sw/ErrorChecker.py
+++ b/src/smartcard/sw/ErrorChecker.py
@@ -1,6 +1,6 @@
 """Base class for status word error checkers.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/sw/ErrorCheckingChain.py
+++ b/src/smartcard/sw/ErrorCheckingChain.py
@@ -1,7 +1,7 @@
 """The error checking chain is a list of status word
 (sw1, sw2) error check strategies.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/sw/ISO7816_4ErrorChecker.py
+++ b/src/smartcard/sw/ISO7816_4ErrorChecker.py
@@ -1,6 +1,6 @@
 """ISO7816-4 error checking strategy.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/sw/ISO7816_4_SW1ErrorChecker.py
+++ b/src/smartcard/sw/ISO7816_4_SW1ErrorChecker.py
@@ -1,6 +1,6 @@
 """ISO7816-4 sw1 only error checker.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/sw/ISO7816_8ErrorChecker.py
+++ b/src/smartcard/sw/ISO7816_8ErrorChecker.py
@@ -1,6 +1,6 @@
 """ISO7816-8 error checker.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/sw/ISO7816_9ErrorChecker.py
+++ b/src/smartcard/sw/ISO7816_9ErrorChecker.py
@@ -1,6 +1,6 @@
 """ISO7816-9 error checker.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/sw/SWExceptions.py
+++ b/src/smartcard/sw/SWExceptions.py
@@ -2,7 +2,7 @@
 
 This module defines the exceptions raised by status word errors or warnings.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/sw/__init__.py
+++ b/src/smartcard/sw/__init__.py
@@ -1,6 +1,6 @@
 """smartcard.sw module for status word error checking.
 
-__author__ = "gemalto http://www.gemalto.com"
+__author__ = "gemalto https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/sw/op21_ErrorChecker.py
+++ b/src/smartcard/sw/op21_ErrorChecker.py
@@ -1,6 +1,6 @@
 """Open Platform 2.1 error checker.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/configcheck.py
+++ b/src/smartcard/test/configcheck.py
@@ -4,7 +4,7 @@ connected readers and cards.
 
 The generated configuration is store in local_config.py.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/framework/testcase_ATR.py
+++ b/src/smartcard/test/framework/testcase_ATR.py
@@ -4,7 +4,7 @@
 This test case can be executed individually, or with all other test cases
 thru testsuite_framework.py.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/framework/testcase_CAtr.py
+++ b/src/smartcard/test/framework/testcase_CAtr.py
@@ -4,7 +4,7 @@
 This test case can be executed individually, or with all other test cases
 thru testsuite_framework.py.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/framework/testcase_Card.py
+++ b/src/smartcard/test/framework/testcase_Card.py
@@ -4,7 +4,7 @@
 This test case can be executed individually, or with all other test cases
 thru testsuite_framework.py.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/framework/testcase_CardConnection.py
+++ b/src/smartcard/test/framework/testcase_CardConnection.py
@@ -4,7 +4,7 @@
 This test case can be executed individually, or with all other test cases
 thru testsuite_framework.py.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/framework/testcase_CardMonitor.py
+++ b/src/smartcard/test/framework/testcase_CardMonitor.py
@@ -4,7 +4,7 @@
 This test case can be executed individually, or with all other test cases
 thru testsuite_framework.py.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/framework/testcase_CardRequest.py
+++ b/src/smartcard/test/framework/testcase_CardRequest.py
@@ -4,7 +4,7 @@
 This test case can be executed individually, or with all other test cases
 thru testsuite_framework.py.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/framework/testcase_CardService.py
+++ b/src/smartcard/test/framework/testcase_CardService.py
@@ -4,7 +4,7 @@
 This test case can be executed individually, or with all other test cases
 thru testsuite_framework.py.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/framework/testcase_CardType.py
+++ b/src/smartcard/test/framework/testcase_CardType.py
@@ -4,7 +4,7 @@
 This test case can be executed individually, or with all other test cases
 thru testsuite_framework.py.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/framework/testcase_ErrorChecking.py
+++ b/src/smartcard/test/framework/testcase_ErrorChecking.py
@@ -4,7 +4,7 @@
 This test case can be executed individually, or with all other test cases
 thru testsuite_framework.py.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/framework/testcase_ExclusiveCardConnection.py
+++ b/src/smartcard/test/framework/testcase_ExclusiveCardConnection.py
@@ -4,7 +4,7 @@
 This test case can be executed individually, or with all other test cases
 thru testsuite_framework.py.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/framework/testcase_readergroups.py
+++ b/src/smartcard/test/framework/testcase_readergroups.py
@@ -4,7 +4,7 @@
 This test case can be executed individually, or with all other test cases
 thru testsuite_framework.py.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/framework/testcase_readermonitor.py
+++ b/src/smartcard/test/framework/testcase_readermonitor.py
@@ -4,7 +4,7 @@
 This test case can be executed individually, or with all other test cases
 thru testsuite_framework.py.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/framework/testcase_readermonitorstress.py
+++ b/src/smartcard/test/framework/testcase_readermonitorstress.py
@@ -4,7 +4,7 @@
 This test case can be executed individually, or with all other test cases
 thru testsuite_framework.py.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/framework/testcase_readers.py
+++ b/src/smartcard/test/framework/testcase_readers.py
@@ -4,7 +4,7 @@
 This test case can be executed individually, or with all other test cases
 thru testsuite_framework.py.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/framework/testcase_ulist.py
+++ b/src/smartcard/test/framework/testcase_ulist.py
@@ -4,7 +4,7 @@
 This test case can be executed individually, or with all other test cases
 thru testsuite_framework.py.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/framework/testcase_utils.py
+++ b/src/smartcard/test/framework/testcase_utils.py
@@ -4,7 +4,7 @@
 This test case can be executed individually, or with all other test cases
 thru testsuite_framework.py.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/framework/testsuite_framework.py
+++ b/src/smartcard/test/framework/testsuite_framework.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 """Unit test suite for smartcard python framework.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/frameworkpcsc/testcase_pcscreadergroups.py
+++ b/src/smartcard/test/frameworkpcsc/testcase_pcscreadergroups.py
@@ -4,7 +4,7 @@
 This test case can be executed individually, or with all other test cases
 thru testsuite_framework.py.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/frameworkpcsc/testsuite_frameworkpcsc.py
+++ b/src/smartcard/test/frameworkpcsc/testsuite_frameworkpcsc.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 """Unit test suite for smartcard python framework over pcsc.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/manual/testcase_manualCardRequest.py
+++ b/src/smartcard/test/manual/testcase_manualCardRequest.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 """Manual unit tests for smartcard.CardRequest
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/scard/testcase_getatr.py
+++ b/src/smartcard/test/scard/testcase_getatr.py
@@ -4,7 +4,7 @@
 This test case can be executed individually, or with all other test cases
 thru testsuite_scard.py.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/scard/testcase_getattrib.py
+++ b/src/smartcard/test/scard/testcase_getattrib.py
@@ -4,7 +4,7 @@
 This test case can be executed individually, or with all other test cases
 thru testsuite_scard.py.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/scard/testcase_geterrormessage.py
+++ b/src/smartcard/test/scard/testcase_geterrormessage.py
@@ -4,7 +4,7 @@
 This test case can be executed individually, or with all other test cases
 thru testsuite_scard.py.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/scard/testcase_listcards.py
+++ b/src/smartcard/test/scard/testcase_listcards.py
@@ -4,7 +4,7 @@
 This test case can be executed individually, or with all other test cases
 thru testsuite_scard.py.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/scard/testcase_locatecards.py
+++ b/src/smartcard/test/scard/testcase_locatecards.py
@@ -4,7 +4,7 @@
 This test case can be executed individually, or with all other test cases
 thru testsuite_scard.py.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/scard/testcase_readergroups.py
+++ b/src/smartcard/test/scard/testcase_readergroups.py
@@ -4,7 +4,7 @@
 This test case can be executed individually, or with all other test cases
 thru testsuite_scard.py.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/scard/testcase_returncodes.py
+++ b/src/smartcard/test/scard/testcase_returncodes.py
@@ -4,7 +4,7 @@
 This test case can be executed individually, or with all other test cases
 thru testsuite_scard.py.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2009 gemalto
 Author: Ludovic Rousseau, mailto:ludovic.rousseau@free.fr

--- a/src/smartcard/test/scard/testcase_transaction.py
+++ b/src/smartcard/test/scard/testcase_transaction.py
@@ -4,7 +4,7 @@
 This test case can be executed individually, or with all other test cases
 thru testsuite_scard.py.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/test/scard/testsuite_scard.py
+++ b/src/smartcard/test/scard/testsuite_scard.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 """Unit test suite for scard python module.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/ulist.py
+++ b/src/smartcard/ulist.py
@@ -2,7 +2,7 @@
 
 [1,2,2,3,3,4] is a valid list, whereas in ulist we can only have [1,2,3,4].
 
-__author__ = "gemalto http://www.gemalto.com"
+__author__ = "gemalto https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/util/__init__.py
+++ b/src/smartcard/util/__init__.py
@@ -1,6 +1,6 @@
 """smartcard.util package
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/wx/APDUHexValidator.py
+++ b/src/smartcard/wx/APDUHexValidator.py
@@ -4,7 +4,7 @@ A wxValidator that matches APDU in hexadecimal such as::
     A4 A0 00 00 02
     A4A0000002
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/wx/APDUTracerPanel.py
+++ b/src/smartcard/wx/APDUTracerPanel.py
@@ -1,6 +1,6 @@
 """Graphical APDU Tracer.
 
-__author__ = "gemalto http://www.gemalto.com"
+__author__ = "gemalto https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com
@@ -22,7 +22,7 @@ along with pyscard; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-# wxPython GUI modules (http://www.wxpython.org)
+# wxPython GUI modules (https://www.wxpython.org/)
 import wx
 
 from smartcard.CardConnectionObserver import CardConnectionObserver

--- a/src/smartcard/wx/CardAndReaderTreePanel.py
+++ b/src/smartcard/wx/CardAndReaderTreePanel.py
@@ -1,6 +1,6 @@
 """wxPython panel display cards/readers as a TreeCtrl.
 
-__author__ = "gemalto http://www.gemalto.com"
+__author__ = "gemalto https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com
@@ -32,7 +32,7 @@ from smartcard.util import toHexString
 import smartcard.wx.SimpleSCardApp
 from smartcard.wx import ICO_SMARTCARD, ICO_READER
 
-# wxPython GUI modules (http://www.wxpython.org)
+# wxPython GUI modules (https://www.wxpython.org/)
 import wx
 
 

--- a/src/smartcard/wx/ReaderToolbar.py
+++ b/src/smartcard/wx/ReaderToolbar.py
@@ -1,6 +1,6 @@
 """wxPython toolbar with reader icons implementing ReaderObserver.
 
-__author__ = "gemalto http://www.gemalto.com"
+__author__ = "gemalto https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/wx/SimpleSCardApp.py
+++ b/src/smartcard/wx/SimpleSCardApp.py
@@ -1,6 +1,6 @@
 """Simple wxPython wxApp for smartcard.
 
-__author__ = "gemalto http://www.gemalto.com"
+__author__ = "gemalto https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/wx/SimpleSCardAppEventObserver.py
+++ b/src/smartcard/wx/SimpleSCardAppEventObserver.py
@@ -1,6 +1,6 @@
 """Smartcard event observer.
 
-__author__ = "gemalto http://www.gemalto.com"
+__author__ = "gemalto https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com

--- a/src/smartcard/wx/SimpleSCardAppFrame.py
+++ b/src/smartcard/wx/SimpleSCardAppFrame.py
@@ -1,6 +1,6 @@
 """Simple wxpython frame for smart card application.
 
-__author__ = "gemalto http://www.gemalto.com"
+__author__ = "gemalto https://www.gemalto.com/"
 __date__ = "November 2006"
 __version__ = "1.4.0"
 

--- a/src/smartcard/wx/__init__.py
+++ b/src/smartcard/wx/__init__.py
@@ -1,6 +1,6 @@
 """wxpython smartcard utility module.
 
-__author__ = "http://www.gemalto.com"
+__author__ = "https://www.gemalto.com/"
 
 Copyright 2001-2012 gemalto
 Author: Jean-Daniel Aussel, mailto:jean-daniel.aussel@gemalto.com


### PR DESCRIPTION
Some of these changes were not mechanical, but required subjective choices:

* Links to MUSCLE and PSCSlite were re-hosted based on Google searches.
* Gemalto.com redirects to a specific page on Thales.com. Gemalto was purchased by Thales, but to retain future redirection, only the URL protocol was modified (HTTP -> HTTPS).
* "Thinking in Python" links on mindview.net no longer resolve, and it's unclear what to update these to.
* Robert Brewer's import code on activestate.com no longer exists, and even ActiveState's intenal site search point to the dead link.