### PR TITLE
Speed up coverage reporting by skipping package installation

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,7 @@ depends = py{3.9, 3.10, 3.11, 3.12}
 description =
     !ci: Generate HTML and console reports
     ci: Generate an XML report
+skip_install = True
 deps =
     coverage
 commands_pre =


### PR DESCRIPTION
~Also, modify the Makefile to use tox for coverage reporting.
Locally, `make coverage` runs in under 7 seconds.~

~If `make coverage` is not fast enough, I can remove the Makefile change.~

Makefile change removed.