### PR TITLE
Test reader groups

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,6 +3,7 @@ coverage
 coveralls
 pylint
 pytest
+pytest-randomly
 setuptools
 tox
 wheel

--- a/src/smartcard/reader/ReaderGroups.py
+++ b/src/smartcard/reader/ReaderGroups.py
@@ -33,14 +33,6 @@ class BadReaderGroupException(SmartcardException):
         SmartcardException.__init__(self, 'Invalid reader group')
 
 
-class DeleteSCardDefaultReaderGroupException(SmartcardException):
-    """Raised when trying to delete SCard$DefaultReaders reader group."""
-
-    def __init__(self):
-        SmartcardException.__init__(
-            self, 'SCard$DefaultReaders cannot be deleted')
-
-
 class innerreadergroups(ulist):
     """Smartcard readers groups private class.
 
@@ -51,9 +43,8 @@ class innerreadergroups(ulist):
     def __init__(self, initlist=None):
         """Retrieve and store list of reader groups"""
         if initlist is None:
-            initlist = self.getreadergroups()
-        if initlist is not None:
-            ulist.__init__(self, initlist)
+            initlist = self.getreadergroups() or []
+        ulist.__init__(self, initlist)
         self.unremovablegroups = []
 
     def __onadditem__(self, item):
@@ -112,7 +103,3 @@ class readergroups(object):
 
     def __getattr__(self, name):
         return getattr(self.instance, name)
-
-
-if __name__ == '__main__':
-    print(readergroups())

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+import smartcard.reader.ReaderGroups
+
+
+@pytest.fixture(autouse=True)
+def reset_reader_groups():
+    """Reader group instances must be reset at the beginning of each test."""
+
+    smartcard.reader.ReaderGroups.readergroups.instance = None
+    yield

--- a/test/test_readergroups.py
+++ b/test/test_readergroups.py
@@ -1,0 +1,89 @@
+import pytest
+
+import smartcard.reader.ReaderGroups
+import smartcard.ulist
+
+
+def test_reader_groups_acts_like_a_singleton():
+    """Verify that the target class *acts* like a singleton."""
+
+    instance_1 = smartcard.reader.ReaderGroups.readergroups()
+    instance_2 = smartcard.reader.ReaderGroups.readergroups()
+    assert instance_1.instance is instance_2.instance
+
+
+def test_reader_groups_method_calls():
+    reader_group = smartcard.reader.ReaderGroups.readergroups()
+    assert len(reader_group.instance) == 0, "No reader groups should be pre-defined"
+
+    list.append(reader_group.instance, "a")
+    assert len(reader_group.instance) == 1, "Unable to add a reader group"
+
+    reader_group.addreadergroup("a")
+    assert len(reader_group.instance) == 1, "Reader groups must be unique"
+
+    with pytest.raises(smartcard.reader.ReaderGroups.BadReaderGroupException):
+        reader_group.addreadergroup(1)
+    with pytest.raises(smartcard.reader.ReaderGroups.BadReaderGroupException):
+        reader_group.removereadergroup(1)
+
+    # .__iter__()
+    assert len(list(reader_group.instance)) == 1
+
+    # No-op calls
+    reader_group.addreadertogroup("no-op", "bogus")
+    reader_group.removereaderfromgroup("no-op", "bogus")
+
+
+# ------------------------------------------------------------------------------------
+# The tests below this line demonstrate serious behavioral problems with readergroups.
+
+
+@pytest.mark.xfail(reason="readergroups is not actually a singleton", strict=True)
+def test_reader_groups_is_a_singleton():
+    """Verify that readergroups is a singleton."""
+
+    instance_1 = smartcard.reader.ReaderGroups.readergroups()
+    instance_2 = smartcard.reader.ReaderGroups.readergroups()
+    assert instance_1 is instance_2
+
+
+@pytest.mark.xfail(reason="initlist parameters may be silently ignored", strict=True)
+def test_demonstrate_initlist_values_may_be_silently_ignored():
+    """Demonstrate that `initlist` parameters may be silently ignored."""
+
+    smartcard.reader.ReaderGroups.readergroups(["a"])
+    reader_group = smartcard.reader.ReaderGroups.readergroups(["b"])
+    assert "b" in reader_group.instance
+
+
+def test_demonstrate_adding_is_impossible():
+    """Demonstrate that `.addreadergroup()` cannot be called."""
+
+    reader_group = smartcard.reader.ReaderGroups.readergroups()
+    with pytest.raises(RecursionError, match="maximum recursion depth exceeded"):
+        reader_group.addreadergroup("a")
+
+
+def test_demonstrate_removing_is_impossible():
+    """Demonstrate that `.removereadergroup()` cannot be called.
+
+    `.removereadergroup()` recurses twice.
+    It successfully removes the value, then fails to find it the second time.
+    """
+
+    reader_group = smartcard.reader.ReaderGroups.readergroups()
+    list.append(reader_group.instance, "a")
+    assert reader_group.instance == ["a"]
+    with pytest.raises(ValueError, match="x not in list"):
+        reader_group.removereadergroup("a")
+    assert reader_group.instance == []
+
+
+def test_demonstrate_getting_is_impossible():
+    """Demonstrate that `.getreadergroups()` returns hard-coded values."""
+
+    reader_group = smartcard.reader.ReaderGroups.readergroups()
+    list.append(reader_group.instance, "a")
+    assert reader_group.instance == ["a"]
+    assert reader_group.getreadergroups() == []


### PR DESCRIPTION
This PR introduces extensive testing of the `readergroups` class, and achieves 100% test coverage of the file.

However, `readergroups` has pathological implementation problems, which are captured in the tests marked with `xfail` or that use `pytest.raises()` to capture failures:

* Calling `readergroups.addreadergroup()` causes a `RecursionError`
* Calling `readergroups.removereadergroup()` causes a `ValueError`
* Calling `readergroups.getreadergroups()` returns a hard-coded empty list

There is at least one side effect I've found when `readergroups` is inherited by the PSCS reader groups subclass, but I haven't added those tests yet.

Now that the problems are captured in the test suite, I intend to work to remove the `readergroups` class entirely.