### PR TITLE
Escalate test suite warnings to errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,13 @@ project-name = "PySCard"
 project-url = "https://github.com/LudovicRousseau/pyscard"
 html-output = "build/docs/apidocs"
 warnings-as-errors = true
+
+
+# pytest
+# ------
+
+[tool.pytest.ini_options]
+addopts = "--color=yes"
+filterwarnings = [
+    "error",
+]


### PR DESCRIPTION
This helps ensure that warnings that CPython ignores by default -- `ResourceWarning` -- or that warn of pending changes -- `DeprecationWarning` -- cause test suite failures in CI and can be addressed.

There are currently no warnings to address.