### PR TITLE
Test Python 3.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
 
         include:
           # Augment the matrix with additional values.
@@ -58,6 +59,7 @@ jobs:
         with:
           python-version: "${{ matrix.cpython }}"
           architecture: "${{ matrix.architecture }}"
+          allow-prereleases: true
 
       - name: "Install build prerequisites (Linux)"
         if: matrix.name == 'Linux'

--- a/setup.py
+++ b/setup.py
@@ -142,6 +142,7 @@ kw = {
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Security",
     ],
 }

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # The following list of Python versions appears in several places in this file.
 #
-#   {3.9, 3.10, 3.11, 3.12}
+#   {3.9, 3.10, 3.11, 3.12, 3.13}
 #
 # This affects parallel test suite execution and wheels that get built,
 # so use search-and-replace to update this list in all locations.
@@ -10,12 +10,12 @@
 envlist =
     pylint
     coverage_erase
-    py{3.9, 3.10, 3.11, 3.12}
+    py{3.9, 3.10, 3.11, 3.12, 3.13}
     coverage_report
     docs
 skip_missing_interpreters = True
 labels =
-    build=build-py{3.9, 3.10, 3.11, 3.12}
+    build=build-py{3.9, 3.10, 3.11, 3.12, 3.13}
 
 [testenv:coverage_erase]
 description = Erase existing coverage reports
@@ -27,14 +27,14 @@ commands =
 
 [testenv]
 depends =
-    py{3.9, 3.10, 3.11, 3.12}: coverage_erase
+    py{3.9, 3.10, 3.11, 3.12, 3.13}: coverage_erase
 deps =
     -r{toxinidir}/dev-requirements.txt
 commands =
     coverage run -m pytest
 
 [testenv:coverage_report{,-ci}]
-depends = py{3.9, 3.10, 3.11, 3.12}
+depends = py{3.9, 3.10, 3.11, 3.12, 3.13}
 description =
     !ci: Generate HTML and console reports
     ci: Generate an XML report
@@ -50,7 +50,7 @@ commands =
     # In CI, simply generate an XML report
     ci: - coverage xml
 
-[testenv:build,build-py{3.9, 3.10, 3.11, 3.12}]
+[testenv:build,build-py{3.9, 3.10, 3.11, 3.12, 3.13}]
 description = Build sdist and wheel files
 skip_install = True
 deps =


### PR DESCRIPTION
Python 3.13 will be released in a few days (its third and final release candidate was published a few days ago).

This PR adds Python 3.13 to the tox test suite and to CI.