### PR TITLE
Eliminate mutable default parameters from methods

### DIFF
--- a/src/smartcard/CardConnection.py
+++ b/src/smartcard/CardConnection.py
@@ -187,7 +187,7 @@ class CardConnection(Observable):
         transmission."""
         return [], 0, 0
 
-    def control(self, controlCode, command=[]):
+    def control(self, controlCode, command=None):
         """Send a control command and buffer.  Internally calls
         L{doControl()} class method and notify observers upon
         command/response events.  Subclasses must override the
@@ -197,6 +197,8 @@ class CardConnection(Observable):
 
         @param command:     list of bytes to transmit
         """
+        if command is None:
+            command = []
         Observable.setChanged(self)
         Observable.notifyObservers(
             self, CardConnectionEvent("command", [controlCode, command])

--- a/src/smartcard/CardConnectionDecorator.py
+++ b/src/smartcard/CardConnectionDecorator.py
@@ -85,8 +85,10 @@ class CardConnectionDecorator(CardConnection):
         """call inner component transmit"""
         return self.component.transmit(command, protocol)
 
-    def control(self, controlCode, command=[]):
+    def control(self, controlCode, command=None):
         """call inner component control"""
+        if command is None:
+            command = []
         return self.component.control(controlCode, command)
 
     def getAttrib(self, attribId):

--- a/src/smartcard/System.py
+++ b/src/smartcard/System.py
@@ -28,7 +28,7 @@ import smartcard.pcsc.PCSCReaderGroups
 import smartcard.reader.ReaderFactory
 
 
-def readers(groups=[]):
+def readers(groups=None):
     """Returns the list of smartcard readers in groups as
     L{smartcard.reader.Reader}.
 
@@ -39,6 +39,8 @@ def readers(groups=[]):
     >>> r=smartcard.readers(['SCard$DefaultReaders', 'MyReaderGroup'])
     """
 
+    if groups is None:
+        groups = []
     return smartcard.reader.ReaderFactory.ReaderFactory.readers(groups)
 
 

--- a/src/smartcard/pcsc/PCSCCardConnection.py
+++ b/src/smartcard/pcsc/PCSCCardConnection.py
@@ -285,7 +285,7 @@ class PCSCCardConnection(CardConnection):
         data = [(x + 256) % 256 for x in response[:-2]]
         return list(data), sw1, sw2
 
-    def doControl(self, controlCode, command=[]):
+    def doControl(self, controlCode, command=None):
         """Transmit a control command to the reader and return response.
 
         @param controlCode: control command
@@ -294,6 +294,8 @@ class PCSCCardConnection(CardConnection):
 
         @return:      response are the response bytes (if any)
         """
+        if command is None:
+            command = []
         CardConnection.doControl(self, controlCode, command)
         hresult, response = SCardControl(self.hcard, controlCode, command)
         if hresult != SCARD_S_SUCCESS:

--- a/src/smartcard/pcsc/PCSCReader.py
+++ b/src/smartcard/pcsc/PCSCReader.py
@@ -31,14 +31,15 @@ from smartcard.reader.Reader import Reader
 from smartcard.scard import *
 
 
-def __PCSCreaders__(hcontext, groups=[]):
+def __PCSCreaders__(hcontext, groups=None):
     """Returns the list of PCSC smartcard readers in PCSC group.
 
     If group is not specified, returns the list of all PCSC smartcard readers.
     """
 
-    # in case we have a string instead of a list
-    if isinstance(groups, str):
+    if groups is None:
+        groups = []
+    elif isinstance(groups, str):
         groups = [groups]
     hresult, readers = SCardListReaders(hcontext, groups)
     if hresult != SCARD_S_SUCCESS:
@@ -104,7 +105,9 @@ class PCSCReader(Reader):
             return PCSCReader(readername)
 
     @staticmethod
-    def readers(groups=[]):
+    def readers(groups=None):
+        if groups is None:
+            groups = []
         creaders = []
         hcontext = PCSCContext().getContext()
 

--- a/src/smartcard/reader/ReaderFactory.py
+++ b/src/smartcard/reader/ReaderFactory.py
@@ -53,7 +53,9 @@ class ReaderFactory:
         return ReaderFactory.factories[clazz].create(readername)
 
     @staticmethod
-    def readers(groups=[]):
+    def readers(groups=None):
+        if groups is None:
+            groups = []
         zreaders = []
         for fm in ReaderFactory.factorymethods:
             zreaders += fm(groups)


### PR DESCRIPTION
Fixed
-----

* Eliminate mutable default parameters from methods.

  Because the parameters are passed to observers, it is possible for an observer to accidentally -- and permanently -- modify a default argument.

  ```python
  observers = [lambda x: x.append("bad")]

  def demo(groups=[]):
      print(groups)
      for observer in observers:
          observer(groups)

  demo()  # []
  demo()  # ["bad"]
  demo()  # ["bad", "bad"]
  ```
