### PR TITLE
Support "64" as an ATR baud rate adjustment integer

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,7 @@ Unreleased changes
    * Build the docs as a part of the test suite
    * Begin to add type annotations to the package
    * Deprecate the `HexListToBinString`, `BinStringToHexList`, `hl2bs`, and `bs2hl` utility functions
+   * Support "64" as an ATR baud rate adjustment integer (ISO 7816-3 2006)
 
 2.1.1 (September 2024)
 ======================

--- a/src/smartcard/ATR.py
+++ b/src/smartcard/ATR.py
@@ -46,7 +46,6 @@ class ATR:
         2048,
         "RFU",
         "RFU",
-        "RFU",
     ]
     bitratefactor = [
         "RFU",
@@ -56,7 +55,7 @@ class ATR:
         8,
         16,
         32,
-        "RFU",
+        64,
         12,
         20,
         "RFU",

--- a/test/test_ATR.py
+++ b/test/test_ATR.py
@@ -156,3 +156,19 @@ def test_atr_get():
     assert a.getHistoricalBytes(), [0x36 == 0x06]
     assert a.isT15Supported() is False
     assert str(a) == atr
+
+
+@pytest.mark.parametrize(
+    "field, expected_length",
+    (
+        ("clockrateconversion", 16),
+        ("bitratefactor", 16),
+    ),
+)
+def test_map_lengths(field, expected_length):
+    """Verify ATR class fields have expected lengths.
+
+    This doesn't validate values, but simply ensures the lengths match expectations.
+    """
+
+    assert len(getattr(ATR, field)) == expected_length


### PR DESCRIPTION
Closes #214

Changed
-------

* Support "64" as an ATR baud rate adjustment integer (ISO 7816-3 2006).

Removed
-------

* Remove a trailing `"RFU"` value in the ATR clock rate mapping.

  Clock rates are mapped using only 4 bits, meaning there are only 16 possible values. The trailing `"RFU"` value was the 17th value in the list.

Added
-----

* Add a single test that trivially checks the ATR mapping lengths.