### PR TITLE
Replace deprecated $function by new $action

### DIFF
--- a/src/smartcard/scard/PcscTypemaps.i
+++ b/src/smartcard/scard/PcscTypemaps.i
@@ -23,7 +23,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 %exception
 {
     Py_BEGIN_ALLOW_THREADS;
-    $function
+    $action
     Py_END_ALLOW_THREADS;
 }
 


### PR DESCRIPTION
The long-deprecated $function was removed from future SWIG 4.4.0. It can be safely replaced by $action.

More information about swig change could be found in the commit [Remove long-deprecated $function variable](https://github.com/swig/swig/commit/3be7697a33c98435865fc713f8ecf7cf10765f13)

The fix was recommended by upstream. 