### PR TITLE
scard.i: define SCARD_PROTOCOL_UNDEFINED when undefined

### DIFF
--- a/src/smartcard/scard/scard.i
+++ b/src/smartcard/scard/scard.i
@@ -165,6 +165,10 @@ Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
 typedef STRING PROVIDERNAME_t;
 
+#ifndef SCARD_PROTOCOL_UNDEFINED
+#define SCARD_PROTOCOL_UNDEFINED 0x00000000
+#endif
+
 %}
 
 %include typemaps.i


### PR DESCRIPTION
Fixes a failure when `SCARD_PROTOCOL_UNDEFINED` is not defined:
```
building 'smartcard.scard._scard' extension
swigging src/smartcard/scard/scard.i to src/smartcard/scard/scard_wrap.c
swig -python -outdir src/smartcard/scard -DPCSCLITE -D__APPLE__ -o src/smartcard/scard/scard_wrap.c src/smartcard/scard/scard.i
creating build/temp.macosx-10.6-ppc-cpython-312/src/smartcard/scard
/usr/bin/gcc-4.2 -Os -arch ppc -isysroot/ -std=c99 -DVER_PRODUCTVERSION=2,3,0,0000 -DVER_PRODUCTVERSION_STR=2.3.0 -DPCSCLITE=1 -D__APPLE__=1 -Isrc/smartcard/scard/ -I/opt/local/Library/Frameworks/Python.framework/Versions/3.12/include/python3.12 -c src/smartcard/scard/helpers.c -o build/temp.macosx-10.6-ppc-cpython-312/src/smartcard/scard/helpers.o
/usr/bin/gcc-4.2 -Os -arch ppc -isysroot/ -std=c99 -DVER_PRODUCTVERSION=2,3,0,0000 -DVER_PRODUCTVERSION_STR=2.3.0 -DPCSCLITE=1 -D__APPLE__=1 -Isrc/smartcard/scard/ -I/opt/local/Library/Frameworks/Python.framework/Versions/3.12/include/python3.12 -c src/smartcard/scard/scard_wrap.c -o build/temp.macosx-10.6-ppc-cpython-312/src/smartcard/scard/scard_wrap.o
In file included from src/smartcard/scard/scard_wrap.c:3283:
src/smartcard/scard/winscarddll.h:279: warning: ‘LPTSTR’ is deprecated
src/smartcard/scard/winscarddll.h:285: warning: ‘LPTSTR’ is deprecated
src/smartcard/scard/winscarddll.h:303: warning: ‘LPTSTR’ is deprecated
src/smartcard/scard/scard_wrap.c: In function ‘_ListReaders’:
src/smartcard/scard/scard_wrap.c:3717: warning: ‘LPTSTR’ is deprecated
src/smartcard/scard/scard_wrap.c: In function ‘_ListReaderGroups’:
src/smartcard/scard/scard_wrap.c:3759: warning: ‘LPTSTR’ is deprecated
src/smartcard/scard/scard_wrap.c:3776: warning: ‘LPTSTR’ is deprecated
src/smartcard/scard/scard_wrap.c: In function ‘_Status’:
src/smartcard/scard/scard_wrap.c:3855: warning: ‘LPTSTR’ is deprecated
src/smartcard/scard/scard_wrap.c: In function ‘_Transmit’:
src/smartcard/scard/scard_wrap.c:3893: error: ‘SCARD_PROTOCOL_UNDEFINED’ undeclared (first use in this function)
src/smartcard/scard/scard_wrap.c:3893: error: (Each undeclared identifier is reported only once
src/smartcard/scard/scard_wrap.c:3893: error: for each function it appears in.)
error: command '/usr/bin/gcc-4.2' failed with exit code 1

ERROR Backend subprocess exited when trying to invoke build_wheel
Command failed:  cd "/opt/local/var/macports/build/py312-pyscard-4e3be781/work/pyscard-2.3.0" && /opt/local/Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 -m build --no-isolation --wheel --outdir /opt/local/var/macports/build/py312-pyscard-4e3be781/work 
Exit code: 1
```