### PR TITLE
Test on Windows ARM64. Fixes #236

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           - "macOS"
           - "Windows (x64)"
           - "Windows (x86)"
-          - "Windows (arm)"
+          - "Windows (arm64)"
 
         cpython:
           - "3.10"
@@ -59,6 +59,10 @@ jobs:
           - name: "Windows (arm)"
             runner: "windows-11-arm"
             architecture: "arm64"
+
+        exclude:
+          - os: "windows-11-arm"
+            cpython: "3.10"
 
     steps:
       - name: "Checkout the repository"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,6 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           - "macOS"
           - "Windows (x64)"
           - "Windows (x86)"
-          - "Windows (arm)"
+          - "Windows (arm64)"
 
         cpython:
           - "3.10"
@@ -58,7 +58,7 @@ jobs:
 
           - name: "Windows (arm)"
             runner: "windows-11-arm"
-            architecture: "arm"
+            architecture: "arm64"
 
     steps:
       - name: "Checkout the repository"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
             architecture: "arm64"
 
         exclude:
-          - os: "windows-11-arm"
+          - name: "Windows (arm64)"
             cpython: "3.10"
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,8 @@ jobs:
           - "macOS"
           - "Windows (x64)"
           - "Windows (x86)"
+          - "Windows (arm)"
+
         cpython:
           - "3.10"
           - "3.11"
@@ -52,6 +54,10 @@ jobs:
           - name: "Windows (x86)"
             runner: "windows-latest"
             architecture: "x86"
+
+          - name: "Windows (arm)"
+            runner: "windows-11-arm"
+            architecture: "arm"
 
     steps:
       - name: "Checkout the repository"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           - "macOS"
           - "Windows (x64)"
           - "Windows (x86)"
-          - "Windows (arm64)"
+          - "Windows (arm)"
 
         cpython:
           - "3.10"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
             runner: "windows-latest"
             architecture: "x86"
 
-          - name: "Windows (arm)"
+          - name: "Windows (arm64)"
             runner: "windows-11-arm"
             architecture: "arm64"
 


### PR DESCRIPTION
- specify arm64, not arm.
- There was no Python 3.10 for Windows arm64 so we need to exclude.